### PR TITLE
Add .env configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example configuration for IP Location Lookup Tool
+DB_FILE=ip_cache.db
+PORT=8080
+DEBUG=True

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,8 @@ Thumbs.db
 # Logs
 *.log
 
+# Environment files
+.env
+
 # Migration script (no longer needed)
 migrate_cache.py

--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ This Flask web application lets you look up location information for individual 
    ```bash
    pip install -r requirements.txt
    ```
-3. Run the application:
+3. Copy the sample environment file and adjust values if needed:
+   ```bash
+   cp .env.example .env
+   ```
+4. Run the application:
    ```bash
    python app.py
    ```
-4. Open `http://localhost:8080` in your browser.
+5. Open `http://localhost:8080` (or the port set in `.env`) in your browser.
 
-Processed files are saved under `results/` and cached IP data is stored in `ip_cache.db`.
+Processed files are saved under `results/` and cached IP data is stored in the database defined by `DB_FILE`.

--- a/app.py
+++ b/app.py
@@ -6,16 +6,22 @@ import io
 import os
 import time
 import json
+from dotenv import load_dotenv
 
 app = Flask(__name__)
+
+# Load configuration from .env file if present
+load_dotenv()
+
+# Configuration with defaults
+DB_FILE = os.getenv("DB_FILE", "ip_cache.db")
+PORT = int(os.getenv("PORT", "8080"))
+DEBUG = os.getenv("DEBUG", "True").lower() == "true"
 
 
 @app.template_filter('timestamp_to_date')
 def timestamp_to_date(timestamp):
     return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(timestamp))
-
-
-DB_FILE = "ip_cache.db"
 
 
 # Initialize database
@@ -391,4 +397,4 @@ def fix_cache():
 
 
 if __name__ == '__main__':
-    app.run(debug=True, port=8080)
+    app.run(debug=DEBUG, port=PORT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask~=3.0.0
 pandas~=2.3.0
 requests~=2.32.4
 tqdm~=4.67.1
+python-dotenv~=1.0.1


### PR DESCRIPTION
## Summary
- load environment variables from `.env` with `python-dotenv`
- document copying `.env.example` to `.env`
- create a sample `.env.example`
- ignore `.env` in git
- update dependencies

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68639fdf4dd8832d919249df1ca93555