### PR TITLE
Add view option for processed files

### DIFF
--- a/app.py
+++ b/app.py
@@ -316,6 +316,19 @@ def list_results():
     return render_template('results.html', files=files)
 
 
+@app.route('/view/<filename>')
+def view_result(filename):
+    filepath = os.path.join('results', filename)
+    if not os.path.exists(filepath):
+        return 'File not found', 404
+    try:
+        df = pd.read_csv(filepath)
+    except Exception as e:
+        return str(e), 500
+    table_html = df.to_html(index=False)
+    return render_template('view.html', filename=filename, table=table_html)
+
+
 @app.route('/download/<filename>')
 def download_result(filename):
     return send_file(os.path.join('results', filename), as_attachment=True)

--- a/templates/results.html
+++ b/templates/results.html
@@ -9,6 +9,8 @@
         th, td { border: 1px solid #ddd; padding: 12px; text-align: left; }
         th { background-color: #f2f2f2; }
         tr:nth-child(even) { background-color: #f9f9f9; }
+        .view-btn { background: #6c757d; color: white; padding: 6px 12px; text-decoration: none; border-radius: 4px; }
+        .view-btn:hover { background: #5a6268; }
         .download-btn { background: #007cba; color: white; padding: 6px 12px; text-decoration: none; border-radius: 4px; }
         .download-btn:hover { background: #005a87; }
         .delete-btn { background: #dc3545; color: white; padding: 6px 12px; border: none; border-radius: 4px; cursor: pointer; margin-left: 5px; }
@@ -42,6 +44,7 @@
                 <td>{{ "%.1f"|format(file.size/1024) }} KB</td>
                 <td>{{ file.modified|int|timestamp_to_date }}</td>
                 <td class="actions">
+                    <a href="/view/{{ file.name }}" class="view-btn">View</a>
                     <a href="/download/{{ file.name }}" class="download-btn">Download</a>
                     <button onclick="deleteFile('{{ file.name }}')" class="delete-btn">Delete</button>
                 </td>

--- a/templates/view.html
+++ b/templates/view.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>View {{ filename }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 1200px; margin: 20px auto; padding: 20px; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+        tr:nth-child(even) { background-color: #f9f9f9; }
+        .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 30px; }
+        .download-btn { background: #007cba; color: white; padding: 6px 12px; text-decoration: none; border-radius: 4px; }
+        .download-btn:hover { background: #005a87; }
+        a { color: #007cba; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>📄 {{ filename }}</h1>
+        <a href="/results">← Back to Processed Files</a>
+    </div>
+
+    <div style="margin-bottom: 15px;">
+        <a href="/download/{{ filename }}" class="download-btn">Download</a>
+    </div>
+
+    {{ table | safe }}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow processed CSVs to be viewed without downloading
- add `view.html` template
- link "View" from processed files list

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6863a1cec0b4832d8725ce2ef802971d