### PR TITLE
Add MySQL connection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ configured you can fetch IP data from any table on the main page. When fetching
 from MySQL you can also specify a start and end time to run a query that counts
 IP occurrences between those timestamps.
 
+Results generated from the DB lookup now include the configured connection name
+in the filename (e.g. `mysql_myconn_table_timestamp.csv`) so it's easy to see
+where each file originated.
+
 Use the `/settings` page to change the default table/column and tweak the
 thresholds used for dynamic IP classification without editing `.env`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IP Location Lookup Tool
 
-This Flask web application lets you look up location information for individual IP addresses or bulk process CSV files containing an IP column named `client_ip`. Results are cached in a local SQLite database and summarized on a statistics page.
+This Flask web application lets you look up location information for individual IP addresses or bulk process CSV files containing an IP column named `client_ip`. Results are cached in a local SQLite database and summarized on a statistics page. You can also configure connections to MySQL databases and fetch IPs directly from any table.
 
 ## Setup
 
@@ -18,6 +18,9 @@ This Flask web application lets you look up location information for individual 
    python app.py
    ```
 5. Open `http://localhost:8080` (or the port set in `.env`) in your browser.
+
+Optional: visit `/connections` in the UI to add MySQL connection details. Once
+configured you can fetch IP data from any table on the main page.
 
 Processed files are saved under `results/` and cached IP data is stored in the database defined by `DB_FILE`.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Flask web application lets you look up location information for individual 
 ## Setup
 
 1. Install Python 3.8 or newer.
-2. Install dependencies:
+2. Install dependencies (MySQL features require `pymysql`):
    ```bash
    pip install -r requirements.txt
    ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This Flask web application lets you look up location information for individual 
 5. Open `http://localhost:8080` (or the port set in `.env`) in your browser.
 
 Optional: visit `/connections` in the UI to add MySQL connection details. Once
-configured you can fetch IP data from any table on the main page.
+configured you can fetch IP data from any table on the main page. When fetching
+from MySQL you can also specify a start and end time to run a query that counts
+IP occurrences between those timestamps.
 
 Processed files are saved under `results/` and cached IP data is stored in the database defined by `DB_FILE`.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ configured you can fetch IP data from any table on the main page. When fetching
 from MySQL you can also specify a start and end time to run a query that counts
 IP occurrences between those timestamps.
 
+Use the `/settings` page to change the default table/column and tweak the
+thresholds used for dynamic IP classification without editing `.env`.
+
 Processed files are saved under `results/` and cached IP data is stored in the database defined by `DB_FILE`.
 
 ## Cached Data

--- a/app.py
+++ b/app.py
@@ -338,6 +338,20 @@ def settings_page():
     row = conn.execute(
         'SELECT default_table, default_ip_column, high_traffic_threshold, subnet_ip_threshold, subnet_view_threshold FROM app_settings WHERE id=1'
     ).fetchone()
+
+    total_cursor = conn.execute('SELECT COUNT(*) FROM ip_cache')
+    total_ips = total_cursor.fetchone()[0]
+
+    unknown_cursor = conn.execute(
+        'SELECT COUNT(*) FROM ip_cache WHERE country = "Unknown" OR region = "Unknown" OR city = "Unknown"'
+    )
+    unknown_count = unknown_cursor.fetchone()[0]
+
+    error_cursor = conn.execute(
+        'SELECT COUNT(*) FROM ip_cache WHERE country = "Error" OR region = "Error" OR city = "Error"'
+    )
+    error_count = error_cursor.fetchone()[0]
+
     conn.close()
     default_table = row[0] if row else ''
     default_ip_col = row[1] if row else 'client_ip'
@@ -351,6 +365,9 @@ def settings_page():
         high_traffic_threshold=high_traffic,
         subnet_ip_threshold=subnet_ip,
         subnet_view_threshold=subnet_view,
+        total_ips=total_ips,
+        unknown_count=unknown_count,
+        error_count=error_count,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -629,13 +629,6 @@ def fetch_mysql():
             mimetype='text/event-stream',
         )
 
-    settings_conn = sqlite3.connect(DB_FILE)
-    settings_conn.execute(
-        'UPDATE app_settings SET default_table=?, default_ip_column=? WHERE id=1',
-        (table, ip_column),
-    )
-    settings_conn.commit()
-    settings_conn.close()
 
     def generate():
         db_conn = sqlite3.connect(DB_FILE)

--- a/app.py
+++ b/app.py
@@ -54,6 +54,19 @@ def init_db():
         """
     )
 
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS app_settings (
+            id INTEGER PRIMARY KEY CHECK(id = 1),
+            default_table TEXT,
+            default_ip_column TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO app_settings (id, default_table, default_ip_column) VALUES (1, '', 'client_ip')"
+    )
+
     # List of required columns and their SQLite types
     required_columns = {
         "status": "TEXT",
@@ -265,14 +278,44 @@ def mysql_lookup_page():
     connections = conn.execute(
         'SELECT id, name, database FROM mysql_connections'
     ).fetchall()
+    settings_row = conn.execute(
+        'SELECT default_table, default_ip_column FROM app_settings WHERE id=1'
+    ).fetchone()
     conn.close()
-    return render_template('mysql_lookup.html', mysql_connections=connections)
+    default_table = settings_row['default_table'] if settings_row else ''
+    default_ip_col = settings_row['default_ip_column'] if settings_row else 'client_ip'
+    return render_template(
+        'mysql_lookup.html',
+        mysql_connections=connections,
+        default_table=default_table,
+        default_ip_col=default_ip_col,
+    )
 
 
-@app.route('/settings')
+@app.route('/settings', methods=['GET', 'POST'])
 def settings_page():
-    """Render the preferences page for MySQL lookup defaults."""
-    return render_template('settings.html')
+    """Configure default table and IP column for MySQL lookups."""
+    conn = sqlite3.connect(DB_FILE)
+    if request.method == 'POST':
+        conn.execute(
+            'UPDATE app_settings SET default_table=?, default_ip_column=? WHERE id=1',
+            (
+                request.form.get('default_table', ''),
+                request.form.get('default_ip_column', 'client_ip'),
+            ),
+        )
+        conn.commit()
+    row = conn.execute(
+        'SELECT default_table, default_ip_column FROM app_settings WHERE id=1'
+    ).fetchone()
+    conn.close()
+    default_table = row[0] if row else ''
+    default_ip_col = row[1] if row else 'client_ip'
+    return render_template(
+        'settings.html',
+        default_table=default_table,
+        default_ip_col=default_ip_col,
+    )
 
 
 @app.route('/stats')
@@ -585,6 +628,14 @@ def fetch_mysql():
             f"data: {json.dumps({'type': 'error', 'message': 'Invalid end time'})}\n\n",
             mimetype='text/event-stream',
         )
+
+    settings_conn = sqlite3.connect(DB_FILE)
+    settings_conn.execute(
+        'UPDATE app_settings SET default_table=?, default_ip_column=? WHERE id=1',
+        (table, ip_column),
+    )
+    settings_conn.commit()
+    settings_conn.close()
 
     def generate():
         db_conn = sqlite3.connect(DB_FILE)

--- a/app.py
+++ b/app.py
@@ -761,7 +761,8 @@ def fetch_mysql():
         total_ips = len(ips)
         processed = 0
         os.makedirs('results', exist_ok=True)
-        filename = f"mysql_{table}_{int(time.time())}.csv"
+        conn_name = re.sub(r'[^A-Za-z0-9]+', '_', row['name']).strip('_')
+        filename = f"mysql_{conn_name}_{table}_{int(time.time())}.csv"
         filepath = os.path.join('results', filename)
 
         with open(filepath, 'w', newline='') as f:

--- a/app.py
+++ b/app.py
@@ -269,6 +269,12 @@ def mysql_lookup_page():
     return render_template('mysql_lookup.html', mysql_connections=connections)
 
 
+@app.route('/settings')
+def settings_page():
+    """Render the preferences page for MySQL lookup defaults."""
+    return render_template('settings.html')
+
+
 @app.route('/stats')
 def view_stats():
     conn = sqlite3.connect(DB_FILE)

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import os
 import time
 import json
 import csv
-import pymysql
+import re
 from dotenv import load_dotenv
 
 app = Flask(__name__)
@@ -535,6 +535,14 @@ def delete_connection(conn_id):
 
 @app.route('/fetch-mysql', methods=['POST'])
 def fetch_mysql():
+    try:
+        import pymysql
+    except ImportError:
+        return Response(
+            f"data: {json.dumps({'type': 'error', 'message': 'pymysql not installed'})}\n\n",
+            mimetype='text/event-stream',
+        )
+
     data = request.get_json()
     connection_id = data.get('connection_id')
     table = data.get('table')
@@ -543,6 +551,13 @@ def fetch_mysql():
     if not connection_id or not table:
         return Response(
             f"data: {json.dumps({'type': 'error', 'message': 'Missing parameters'})}\n\n",
+            mimetype='text/event-stream',
+        )
+
+    valid_name = re.compile(r'^\w+$')
+    if not valid_name.match(table) or not valid_name.match(ip_column):
+        return Response(
+            f"data: {json.dumps({'type': 'error', 'message': 'Invalid table or column name'})}\n\n",
             mimetype='text/event-stream',
         )
 

--- a/app.py
+++ b/app.py
@@ -255,13 +255,18 @@ def get_ip_location(ip, use_delay=False):
 
 @app.route('/')
 def index():
+    return render_template('index.html')
+
+
+@app.route('/mysql-lookup')
+def mysql_lookup_page():
     conn = sqlite3.connect(DB_FILE)
     conn.row_factory = sqlite3.Row
     connections = conn.execute(
         'SELECT id, name, database FROM mysql_connections'
     ).fetchall()
     conn.close()
-    return render_template('index.html', mysql_connections=connections)
+    return render_template('mysql_lookup.html', mysql_connections=connections)
 
 
 @app.route('/stats')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas~=2.3.0
 requests~=2.32.4
 tqdm~=4.67.1
 python-dotenv~=1.0.1
+pymysql~=1.1.0

--- a/static/style.css
+++ b/static/style.css
@@ -4,6 +4,10 @@ body {
     background-color: #f8fafc;
 }
 
+.navbar .nav-link.active {
+    font-weight: 600;
+}
+
 .container {
     max-width: 1100px;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -25,3 +25,7 @@ a {
 #mysqlProgress {
     max-width: 400px;
 }
+
+#mysqlLog {
+    max-width: 400px;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -17,3 +17,7 @@ a {
 .likely-fake-row>th {
     background-color: #ed8b8b !important;
 }
+
+#mysqlProgress {
+    max-width: 400px;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,7 @@
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('list_results') }}"><i class="bi bi-folder2-open"></i> Files</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('mysql_lookup_page') }}"><i class="bi bi-search"></i> DB Lookup</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('manage_connections') }}"><i class="bi bi-database"></i> MySQL</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('settings_page') }}"><i class="bi bi-gear"></i> Settings</a></li>
                 </ul>
             </div>
         </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('view_stats') }}"><i class="bi bi-bar-chart"></i> Statistics</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('view_cache') }}"><i class="bi bi-hdd"></i> Cache</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('list_results') }}"><i class="bi bi-folder2-open"></i> Files</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('mysql_lookup_page') }}"><i class="bi bi-search"></i> DB Lookup</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('manage_connections') }}"><i class="bi bi-database"></i> MySQL</a></li>
                 </ul>
             </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('view_stats') }}"><i class="bi bi-bar-chart"></i> Statistics</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('view_cache') }}"><i class="bi bi-hdd"></i> Cache</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('list_results') }}"><i class="bi bi-folder2-open"></i> Files</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('manage_connections') }}"><i class="bi bi-database"></i> MySQL</a></li>
                 </ul>
             </div>
         </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,12 +20,27 @@
             </button>
             <div class="collapse navbar-collapse" id="mainNav">
                 <ul class="navbar-nav ms-auto">
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('view_stats') }}"><i class="bi bi-bar-chart"></i> Statistics</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('view_cache') }}"><i class="bi bi-hdd"></i> Cache</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_results') }}"><i class="bi bi-folder2-open"></i> Files</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('mysql_lookup_page') }}"><i class="bi bi-search"></i> DB Lookup</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('manage_connections') }}"><i class="bi bi-database"></i> MySQL</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('settings_page') }}"><i class="bi bi-gear"></i> Settings</a></li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.path == '/' %}active{% endif %}" href="{{ url_for('index') }}"><i class="bi bi-house"></i> Home</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.path.startswith('/stats') %}active{% endif %}" href="{{ url_for('view_stats') }}"><i class="bi bi-bar-chart"></i> Statistics</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.path.startswith('/cache') %}active{% endif %}" href="{{ url_for('view_cache') }}"><i class="bi bi-hdd"></i> Cache</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.path.startswith('/results') or request.path.startswith('/view') %}active{% endif %}" href="{{ url_for('list_results') }}"><i class="bi bi-folder2-open"></i> Files</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.path.startswith('/mysql-lookup') %}active{% endif %}" href="{{ url_for('mysql_lookup_page') }}"><i class="bi bi-search"></i> DB Lookup</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.path.startswith('/connections') %}active{% endif %}" href="{{ url_for('manage_connections') }}"><i class="bi bi-database"></i> MySQL</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.path.startswith('/settings') %}active{% endif %}" href="{{ url_for('settings_page') }}"><i class="bi bi-gear"></i> Settings</a>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/templates/connections.html
+++ b/templates/connections.html
@@ -7,24 +7,37 @@
 {% endblock %}
 {% block content %}
 <h1 class="mb-4">🔌 MySQL Connections</h1>
-<div class="card p-4 shadow-sm mb-3">
-    <form method="post">
-        <div class="row g-2">
-            <div class="col"><input type="text" class="form-control" name="name" placeholder="Name" required></div>
-            <div class="col"><input type="text" class="form-control" name="host" placeholder="Host" required></div>
-            <div class="col"><input type="number" class="form-control" name="port" value="3306" placeholder="Port" required></div>
-            <div class="col"><input type="text" class="form-control" name="user" placeholder="User" required></div>
-            <div class="col"><input type="password" class="form-control" name="password" placeholder="Password" required></div>
-            <div class="col"><input type="text" class="form-control" name="database" placeholder="Database" required></div>
-            <div class="col"><button type="submit" class="btn btn-primary">Add</button></div>
-        </div>
+
+<button class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#addConnModal">Add Connection</button>
+
+<!-- Add connection modal -->
+<div class="modal fade" id="addConnModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form method="post" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Add Connection</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3"><label class="form-label">Name</label><input type="text" class="form-control" name="name" required></div>
+        <div class="mb-3"><label class="form-label">Host</label><input type="text" class="form-control" name="host" required></div>
+        <div class="mb-3"><label class="form-label">Port</label><input type="number" class="form-control" name="port" value="3306" required></div>
+        <div class="mb-3"><label class="form-label">User</label><input type="text" class="form-control" name="user" required></div>
+        <div class="mb-3"><label class="form-label">Password</label><input type="password" class="form-control" name="password" required></div>
+        <div class="mb-3"><label class="form-label">Database</label><input type="text" class="form-control" name="database" required></div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
     </form>
+  </div>
 </div>
+
 {% if connections %}
 <div class="card p-4 shadow-sm">
     <table class="table table-sm table-striped">
         <thead>
-            <tr><th>Name</th><th>Host</th><th>Port</th><th>User</th><th>Database</th><th></th></tr>
+            <tr><th>Name</th><th>Host</th><th>Port</th><th>User</th><th>Database</th><th>Actions</th></tr>
         </thead>
         <tbody>
         {% for c in connections %}
@@ -34,8 +47,9 @@
                 <td>{{ c['port'] }}</td>
                 <td>{{ c['user'] }}</td>
                 <td>{{ c['database'] }}</td>
-                <td>
-                    <form method="post" action="{{ url_for('delete_connection', conn_id=c['id']) }}" onsubmit="return confirm('Delete connection?');">
+                <td class="text-nowrap">
+                    <button type="button" class="btn btn-secondary btn-sm me-1" onclick="testConn({{ c['id'] }})">Test</button>
+                    <form method="post" class="d-inline" action="{{ url_for('delete_connection', conn_id=c['id']) }}" onsubmit="return confirm('Delete connection?');">
                         <button class="btn btn-danger btn-sm">Delete</button>
                     </form>
                 </td>
@@ -47,4 +61,24 @@
 {% else %}
 <p>No connections configured.</p>
 {% endif %}
+
+<div id="testAlert" class="alert d-none mt-3"></div>
+
+<script>
+async function testConn(id) {
+    const alertBox = document.getElementById('testAlert');
+    alertBox.className = 'alert alert-info';
+    alertBox.textContent = 'Testing connection...';
+    alertBox.classList.remove('d-none');
+    const resp = await fetch(`/connections/test/${id}`, {method: 'POST'});
+    const data = await resp.json();
+    if (data.success) {
+        alertBox.className = 'alert alert-success';
+        alertBox.textContent = 'Connection successful';
+    } else {
+        alertBox.className = 'alert alert-danger';
+        alertBox.textContent = 'Error: ' + (data.message || 'Failed');
+    }
+}
+</script>
 {% endblock %}

--- a/templates/connections.html
+++ b/templates/connections.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% block title %}MySQL Connections{% endblock %}
+{% block extra_head %}
+<style>
+    .table-sm th, .table-sm td { vertical-align: middle; }
+</style>
+{% endblock %}
+{% block content %}
+<h1 class="mb-4">🔌 MySQL Connections</h1>
+<div class="card p-4 shadow-sm mb-3">
+    <form method="post">
+        <div class="row g-2">
+            <div class="col"><input type="text" class="form-control" name="name" placeholder="Name" required></div>
+            <div class="col"><input type="text" class="form-control" name="host" placeholder="Host" required></div>
+            <div class="col"><input type="number" class="form-control" name="port" value="3306" placeholder="Port" required></div>
+            <div class="col"><input type="text" class="form-control" name="user" placeholder="User" required></div>
+            <div class="col"><input type="password" class="form-control" name="password" placeholder="Password" required></div>
+            <div class="col"><input type="text" class="form-control" name="database" placeholder="Database" required></div>
+            <div class="col"><button type="submit" class="btn btn-primary">Add</button></div>
+        </div>
+    </form>
+</div>
+{% if connections %}
+<div class="card p-4 shadow-sm">
+    <table class="table table-sm table-striped">
+        <thead>
+            <tr><th>Name</th><th>Host</th><th>Port</th><th>User</th><th>Database</th><th></th></tr>
+        </thead>
+        <tbody>
+        {% for c in connections %}
+            <tr>
+                <td>{{ c['name'] }}</td>
+                <td>{{ c['host'] }}</td>
+                <td>{{ c['port'] }}</td>
+                <td>{{ c['user'] }}</td>
+                <td>{{ c['database'] }}</td>
+                <td>
+                    <form method="post" action="{{ url_for('delete_connection', conn_id=c['id']) }}" onsubmit="return confirm('Delete connection?');">
+                        <button class="btn btn-danger btn-sm">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p>No connections configured.</p>
+{% endif %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
     <h3 class="mb-3">MySQL Table Lookup</h3>
     {% if mysql_connections %}
     <div class="row g-2 mb-2">
-        <div class="col-md-4">
+        <div class="col-md-3">
             <select id="mysqlConn" class="form-select">
                 {% for c in mysql_connections %}
                     <option value="{{ c['id'] }}">{{ c['name'] }} ({{ c['database'] }})</option>
@@ -32,8 +32,12 @@
             </select>
         </div>
         <div class="col-md-3"><input type="text" id="mysqlTable" class="form-control" placeholder="Table"/></div>
-        <div class="col-md-3"><input type="text" id="mysqlIpCol" class="form-control" value="client_ip" placeholder="IP column"/></div>
-        <div class="col-md-2"><button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button></div>
+        <div class="col-md-2"><input type="text" id="mysqlIpCol" class="form-control" value="client_ip" placeholder="IP column"/></div>
+        <div class="col-md-2"><input type="datetime-local" id="mysqlStart" class="form-control"/></div>
+        <div class="col-md-2"><input type="datetime-local" id="mysqlEnd" class="form-control"/></div>
+    </div>
+    <div class="row g-2 mb-2">
+        <div class="col-md-2 ms-auto"><button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button></div>
     </div>
     <div id="mysqlProgress" class="mt-2"></div>
     {% else %}
@@ -224,6 +228,8 @@
         const conn = document.getElementById('mysqlConn').value;
         const table = document.getElementById('mysqlTable').value;
         const col = document.getElementById('mysqlIpCol').value || 'client_ip';
+        const start = document.getElementById('mysqlStart').value;
+        const end = document.getElementById('mysqlEnd').value;
         if (!conn || !table) return;
 
         const progress = document.getElementById('mysqlProgress');
@@ -232,7 +238,13 @@
         const response = await fetch('/fetch-mysql', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({connection_id: conn, table: table, ip_column: col})
+            body: JSON.stringify({
+                connection_id: conn,
+                table: table,
+                ip_column: col,
+                start_time: start ? start.replace('T', ' ') + ':00' : null,
+                end_time: end ? end.replace('T', ' ') + ':00' : null
+            })
         });
 
         const reader = response.body.getReader();

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,30 +20,6 @@
     <div id="result"></div>
 </div>
 
-<div class="section card p-4 shadow-sm">
-    <h3 class="mb-3">MySQL Table Lookup</h3>
-    {% if mysql_connections %}
-    <div class="row g-2 mb-2">
-        <div class="col-md-3">
-            <select id="mysqlConn" class="form-select">
-                {% for c in mysql_connections %}
-                    <option value="{{ c['id'] }}">{{ c['name'] }} ({{ c['database'] }})</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="col-md-3"><input type="text" id="mysqlTable" class="form-control" placeholder="Table"/></div>
-        <div class="col-md-2"><input type="text" id="mysqlIpCol" class="form-control" value="client_ip" placeholder="IP column"/></div>
-        <div class="col-md-2"><input type="datetime-local" id="mysqlStart" class="form-control"/></div>
-        <div class="col-md-2"><input type="datetime-local" id="mysqlEnd" class="form-control"/></div>
-    </div>
-    <div class="row g-2 mb-2">
-        <div class="col-md-2 ms-auto"><button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button></div>
-    </div>
-    <div id="mysqlProgress" class="mt-2"></div>
-    {% else %}
-    <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
-    {% endif %}
-</div>
 
 <div class="section card p-4 shadow-sm">
     <h3 class="mb-3">CSV File Processing</h3>
@@ -224,51 +200,5 @@
         return `${minutes}m ${remainingSeconds}s`;
     }
 
-    async function fetchMySQL() {
-        const conn = document.getElementById('mysqlConn').value;
-        const table = document.getElementById('mysqlTable').value;
-        const col = document.getElementById('mysqlIpCol').value || 'client_ip';
-        const start = document.getElementById('mysqlStart').value;
-        const end = document.getElementById('mysqlEnd').value;
-        if (!conn || !table) return;
-
-        const progress = document.getElementById('mysqlProgress');
-        progress.textContent = 'Starting...';
-
-        const response = await fetch('/fetch-mysql', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({
-                connection_id: conn,
-                table: table,
-                ip_column: col,
-                start_time: start ? start.replace('T', ' ') + ':00' : null,
-                end_time: end ? end.replace('T', ' ') + ':00' : null
-            })
-        });
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        while (true) {
-            const {done, value} = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, {stream:true});
-            const lines = buffer.split('\n');
-            buffer = lines.pop();
-            for (const line of lines) {
-                if (line.startsWith('data: ')) {
-                    const data = JSON.parse(line.slice(6));
-                    if (data.type === 'progress') {
-                        progress.textContent = `${data.processed}/${data.total} IPs processed`;
-                    } else if (data.type === 'complete') {
-                        progress.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
-                    } else if (data.type === 'error') {
-                        progress.textContent = `Error: ${data.message}`;
-                    }
-                }
-            }
-        }
-    }
 </script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,27 @@
 </div>
 
 <div class="section card p-4 shadow-sm">
+    <h3 class="mb-3">MySQL Table Lookup</h3>
+    {% if mysql_connections %}
+    <div class="row g-2 mb-2">
+        <div class="col-md-4">
+            <select id="mysqlConn" class="form-select">
+                {% for c in mysql_connections %}
+                    <option value="{{ c['id'] }}">{{ c['name'] }} ({{ c['database'] }})</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-3"><input type="text" id="mysqlTable" class="form-control" placeholder="Table"/></div>
+        <div class="col-md-3"><input type="text" id="mysqlIpCol" class="form-control" value="client_ip" placeholder="IP column"/></div>
+        <div class="col-md-2"><button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button></div>
+    </div>
+    <div id="mysqlProgress" class="mt-2"></div>
+    {% else %}
+    <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
+    {% endif %}
+</div>
+
+<div class="section card p-4 shadow-sm">
     <h3 class="mb-3">CSV File Processing</h3>
     <p>Upload CSV files with <code>client_ip</code> column to get location data for all IPs.</p>
     <input type="file" id="csvFiles" class="form-control mb-3" accept=".csv" multiple>
@@ -197,6 +218,45 @@
         const minutes = Math.floor(seconds / 60);
         const remainingSeconds = seconds % 60;
         return `${minutes}m ${remainingSeconds}s`;
+    }
+
+    async function fetchMySQL() {
+        const conn = document.getElementById('mysqlConn').value;
+        const table = document.getElementById('mysqlTable').value;
+        const col = document.getElementById('mysqlIpCol').value || 'client_ip';
+        if (!conn || !table) return;
+
+        const progress = document.getElementById('mysqlProgress');
+        progress.textContent = 'Starting...';
+
+        const response = await fetch('/fetch-mysql', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({connection_id: conn, table: table, ip_column: col})
+        });
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        while (true) {
+            const {done, value} = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, {stream:true});
+            const lines = buffer.split('\n');
+            buffer = lines.pop();
+            for (const line of lines) {
+                if (line.startsWith('data: ')) {
+                    const data = JSON.parse(line.slice(6));
+                    if (data.type === 'progress') {
+                        progress.textContent = `${data.processed}/${data.total} IPs processed`;
+                    } else if (data.type === 'complete') {
+                        progress.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
+                    } else if (data.type === 'error') {
+                        progress.textContent = `Error: ${data.message}`;
+                    }
+                }
+            }
+        }
     }
 </script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,13 +3,38 @@
 {% block extra_head %}
 <style>
     .section { margin: 30px 0; }
-    .processing-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.1); z-index: 1000; display: none; }
-    .processing-message { position: fixed; top: 20px; right: 20px; background: #007cba; color: white; padding: 10px 20px; border-radius: 5px; z-index: 1001; display: none; }
+    .processing-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0,0,0,0.3);
+        z-index: 1000;
+        display: none;
+        align-items: center;
+        justify-content: center;
+    }
+    .processing-message {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        background: #007cba;
+        color: white;
+        padding: 10px 20px;
+        border-radius: 5px;
+        z-index: 1001;
+        display: none;
+    }
 </style>
 {% endblock %}
 {% block content %}
-<div class="processing-overlay" id="processingOverlay"></div>
+<div class="processing-overlay" id="processingOverlay">
+    <div class="spinner-border text-light" role="status"></div>
+</div>
 <div class="processing-message" id="processingMessage">⚠️ Processing in progress - Please don't leave this page</div>
+
+<h1 class="text-center mb-4">IP Location Lookup Tool</h1>
 
 <div class="section card p-4 shadow-sm">
     <h3 class="mb-3">Single IP Lookup</h3>

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -36,11 +36,11 @@
         </div>
         <div class="col-md-4">
             <label class="form-label">Start time</label>
-            <input type="datetime-local" id="mysqlStart" class="form-control">
+            <input type="text" id="mysqlStart" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
         </div>
         <div class="col-md-4">
             <label class="form-label">End time</label>
-            <input type="datetime-local" id="mysqlEnd" class="form-control">
+            <input type="text" id="mysqlEnd" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
         </div>
     </div>
     <div class="row g-2 mb-2">
@@ -59,12 +59,17 @@
     {% endif %}
 </div>
 <script>
-function setDateInput(elem, d) {
-    // Format the date in the user's local timezone so the displayed
-    // value matches the expected local time regardless of offset.
+function formatForDB(d) {
+    // Convert a Date to YYYY-MM-DD HH:MM:SS in the browser's local timezone
     const offsetMs = d.getTimezoneOffset() * 60000;
-    const localISO = new Date(d.getTime() - offsetMs).toISOString().slice(0, 16);
-    elem.value = localISO;
+    return new Date(d.getTime() - offsetMs)
+        .toISOString()
+        .slice(0, 19)
+        .replace('T', ' ');
+}
+
+function setDateInput(elem, d) {
+    elem.value = formatForDB(d);
 }
 
 function applyDateRange() {
@@ -125,8 +130,8 @@ async function fetchMySQL() {
             connection_id: conn,
             table: table,
             ip_column: col,
-            start_time: start ? start.replace('T', ' ') + ':00' : null,
-            end_time: end ? end.replace('T', ' ') + ':00' : null
+            start_time: start || null,
+            end_time: end || null
         })
     });
 

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -60,9 +60,8 @@
 </div>
 <script>
 function toInputValue(d) {
-    const pad = n => n.toString().padStart(2, '0');
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
-        `T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+    return local.toISOString().slice(0, 16);
 }
 
 function applyDateRange() {

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -16,11 +16,11 @@
         </div>
         <div class="col-md-4">
             <label class="form-label">Table</label>
-            <input type="text" id="mysqlTable" class="form-control" placeholder="Table name">
+            <input type="text" id="mysqlTable" class="form-control" placeholder="Table name" value="{{ default_table }}">
         </div>
         <div class="col-md-4">
             <label class="form-label">IP column</label>
-            <input type="text" id="mysqlIpCol" class="form-control" value="client_ip">
+            <input type="text" id="mysqlIpCol" class="form-control" value="{{ default_ip_col }}">
         </div>
     </div>
     <div class="row g-3 mb-2">
@@ -115,12 +115,6 @@ function applyDateRange(useSaved=false) {
 document.getElementById('dateRange').addEventListener('change', applyDateRange);
 
 document.addEventListener('DOMContentLoaded', () => {
-    const savedTable = localStorage.getItem('mysql_table');
-    if (savedTable) document.getElementById('mysqlTable').value = savedTable;
-
-    const savedIpCol = localStorage.getItem('mysql_ip_column');
-    if (savedIpCol) document.getElementById('mysqlIpCol').value = savedIpCol;
-
     const savedRange = localStorage.getItem('mysql_date_range') || 'today';
     document.getElementById('dateRange').value = savedRange;
     applyDateRange(true);
@@ -136,8 +130,6 @@ async function fetchMySQL() {
     if (!conn || !table) return;
 
     // Remember selections for next visit
-    localStorage.setItem('mysql_table', table);
-    localStorage.setItem('mysql_ip_column', col);
     localStorage.setItem('mysql_date_range', range);
     localStorage.setItem('mysql_start_time', start);
     localStorage.setItem('mysql_end_time', end);

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -6,7 +6,7 @@
     {% if mysql_connections %}
     <p>Select a connection and table to fetch unique IPs with location data.</p>
     <div class="row g-3 mb-2">
-        <div class="col-md-3">
+        <div class="col-md-4">
             <label class="form-label">Connection</label>
             <select id="mysqlConn" class="form-select">
                 {% for c in mysql_connections %}
@@ -14,19 +14,31 @@
                 {% endfor %}
             </select>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-4">
             <label class="form-label">Table</label>
             <input type="text" id="mysqlTable" class="form-control" placeholder="Table name">
         </div>
-        <div class="col-md-2">
+        <div class="col-md-4">
             <label class="form-label">IP column</label>
             <input type="text" id="mysqlIpCol" class="form-control" value="client_ip">
         </div>
-        <div class="col-md-2">
+    </div>
+    <div class="row g-3 mb-2">
+        <div class="col-md-4">
+            <label class="form-label">Date range</label>
+            <select id="dateRange" class="form-select">
+                <option value="custom">Custom</option>
+                <option value="today">Today</option>
+                <option value="yesterday">Yesterday</option>
+                <option value="last7">Last 7 Days</option>
+                <option value="last30">Last 30 Days</option>
+            </select>
+        </div>
+        <div class="col-md-4">
             <label class="form-label">Start time</label>
             <input type="datetime-local" id="mysqlStart" class="form-control">
         </div>
-        <div class="col-md-2">
+        <div class="col-md-4">
             <label class="form-label">End time</label>
             <input type="datetime-local" id="mysqlEnd" class="form-control">
         </div>
@@ -36,12 +48,52 @@
             <button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button>
         </div>
     </div>
-    <div id="mysqlProgress" class="mt-2"></div>
-    {% else %}
+    <div id="mysqlProgress" class="mt-2">
+        <div class="progress" style="display:none; height:20px;">
+            <div class="progress-bar" id="mysqlProgressBar" style="width:0%;"></div>
+        </div>
+        <div id="mysqlProgressText" class="mt-1"></div>
+    </div>
     <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
     {% endif %}
 </div>
 <script>
+function applyDateRange() {
+    const range = document.getElementById('dateRange').value;
+    const startInput = document.getElementById('mysqlStart');
+    const endInput = document.getElementById('mysqlEnd');
+    const now = new Date();
+    let start, end;
+    switch(range) {
+        case 'today':
+            start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+            end = new Date(start.getTime() + 86400000);
+            break;
+        case 'yesterday':
+            start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
+            end = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+            break;
+        case 'last7':
+            start = new Date(now.getTime() - 7*86400000);
+            end = now;
+            break;
+        case 'last30':
+            start = new Date(now.getTime() - 30*86400000);
+            end = now;
+            break;
+        default:
+            startInput.disabled = false;
+            endInput.disabled = false;
+            return;
+    }
+    startInput.value = start.toISOString().slice(0,16);
+    endInput.value = end.toISOString().slice(0,16);
+    startInput.disabled = true;
+    endInput.disabled = true;
+}
+
+document.getElementById('dateRange').addEventListener('change', applyDateRange);
+
 async function fetchMySQL() {
     const conn = document.getElementById('mysqlConn').value;
     const table = document.getElementById('mysqlTable').value;
@@ -51,7 +103,11 @@ async function fetchMySQL() {
     if (!conn || !table) return;
 
     const progress = document.getElementById('mysqlProgress');
-    progress.textContent = 'Starting...';
+    const bar = document.getElementById('mysqlProgressBar');
+    const text = document.getElementById('mysqlProgressText');
+    bar.style.width = '0%';
+    progress.querySelector('.progress').style.display = 'block';
+    text.textContent = 'Starting...';
 
     const response = await fetch('/fetch-mysql', {
         method: 'POST',
@@ -78,11 +134,14 @@ async function fetchMySQL() {
             if (line.startsWith('data: ')) {
                 const data = JSON.parse(line.slice(6));
                 if (data.type === 'progress') {
-                    progress.textContent = `${data.processed}/${data.total} IPs processed`;
+                    const pct = Math.round(data.processed / data.total * 100);
+                    bar.style.width = pct + '%';
+                    text.textContent = `${data.processed}/${data.total} IPs`;
                 } else if (data.type === 'complete') {
-                    progress.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
+                    bar.style.width = '100%';
+                    text.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
                 } else if (data.type === 'error') {
-                    progress.textContent = `Error: ${data.message}`;
+                    text.textContent = `Error: ${data.message}`;
                 }
             }
         }

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -1,0 +1,92 @@
+{% extends 'base.html' %}
+{% block title %}MySQL Table Lookup{% endblock %}
+{% block content %}
+<h1 class="mb-4">🔍 MySQL Table Lookup</h1>
+<div class="card p-4 shadow-sm">
+    {% if mysql_connections %}
+    <p>Select a connection and table to fetch unique IPs with location data.</p>
+    <div class="row g-3 mb-2">
+        <div class="col-md-3">
+            <label class="form-label">Connection</label>
+            <select id="mysqlConn" class="form-select">
+                {% for c in mysql_connections %}
+                    <option value="{{ c['id'] }}">{{ c['name'] }} ({{ c['database'] }})</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">Table</label>
+            <input type="text" id="mysqlTable" class="form-control" placeholder="Table name">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">IP column</label>
+            <input type="text" id="mysqlIpCol" class="form-control" value="client_ip">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Start time</label>
+            <input type="datetime-local" id="mysqlStart" class="form-control">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">End time</label>
+            <input type="datetime-local" id="mysqlEnd" class="form-control">
+        </div>
+    </div>
+    <div class="row g-2 mb-2">
+        <div class="col-md-2 ms-auto">
+            <button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button>
+        </div>
+    </div>
+    <div id="mysqlProgress" class="mt-2"></div>
+    {% else %}
+    <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
+    {% endif %}
+</div>
+<script>
+async function fetchMySQL() {
+    const conn = document.getElementById('mysqlConn').value;
+    const table = document.getElementById('mysqlTable').value;
+    const col = document.getElementById('mysqlIpCol').value || 'client_ip';
+    const start = document.getElementById('mysqlStart').value;
+    const end = document.getElementById('mysqlEnd').value;
+    if (!conn || !table) return;
+
+    const progress = document.getElementById('mysqlProgress');
+    progress.textContent = 'Starting...';
+
+    const response = await fetch('/fetch-mysql', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            connection_id: conn,
+            table: table,
+            ip_column: col,
+            start_time: start ? start.replace('T', ' ') + ':00' : null,
+            end_time: end ? end.replace('T', ' ') + ':00' : null
+        })
+    });
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, {stream:true});
+        const lines = buffer.split('\n');
+        buffer = lines.pop();
+        for (const line of lines) {
+            if (line.startsWith('data: ')) {
+                const data = JSON.parse(line.slice(6));
+                if (data.type === 'progress') {
+                    progress.textContent = `${data.processed}/${data.total} IPs processed`;
+                } else if (data.type === 'complete') {
+                    progress.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
+                } else if (data.type === 'error') {
+                    progress.textContent = `Error: ${data.message}`;
+                }
+            }
+        }
+    }
+}
+</script>
+{% endblock %}

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -54,6 +54,7 @@
         </div>
         <div id="mysqlProgressText" class="mt-1"></div>
     </div>
+    {% else %}
     <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
     {% endif %}
 </div>
@@ -67,7 +68,7 @@ function applyDateRange() {
     switch(range) {
         case 'today':
             start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-            end = new Date(start.getTime() + 86400000);
+            end = now;
             break;
         case 'yesterday':
             start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -59,6 +59,12 @@
     {% endif %}
 </div>
 <script>
+function toInputValue(d) {
+    const pad = n => n.toString().padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+        `T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 function applyDateRange() {
     const range = document.getElementById('dateRange').value;
     const startInput = document.getElementById('mysqlStart');
@@ -87,8 +93,8 @@ function applyDateRange() {
             endInput.disabled = false;
             return;
     }
-    startInput.value = start.toISOString().slice(0,16);
-    endInput.value = end.toISOString().slice(0,16);
+    startInput.value = toInputValue(start);
+    endInput.value = toInputValue(end);
     startInput.disabled = true;
     endInput.disabled = true;
 }

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -60,7 +60,10 @@
 </div>
 <script>
 function setDateInput(elem, d) {
-    elem.valueAsNumber = d.getTime() - d.getTimezoneOffset() * 60000;
+    // valueAsNumber expects milliseconds since epoch in UTC but represents the
+    // value in the user's local timezone. Passing the raw timestamp avoids
+    // double-applying the timezone offset.
+    elem.valueAsNumber = d.getTime();
 }
 
 function applyDateRange() {

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -59,9 +59,8 @@
     {% endif %}
 </div>
 <script>
-function toInputValue(d) {
-    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-    return local.toISOString().slice(0, 16);
+function setDateInput(elem, d) {
+    elem.valueAsNumber = d.getTime() - d.getTimezoneOffset() * 60000;
 }
 
 function applyDateRange() {
@@ -92,8 +91,8 @@ function applyDateRange() {
             endInput.disabled = false;
             return;
     }
-    startInput.value = toInputValue(start);
-    endInput.value = toInputValue(end);
+    setDateInput(startInput, start);
+    setDateInput(endInput, end);
     startInput.disabled = true;
     endInput.disabled = true;
 }

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -118,6 +118,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const savedTable = localStorage.getItem('mysql_table');
     if (savedTable) document.getElementById('mysqlTable').value = savedTable;
 
+    const savedIpCol = localStorage.getItem('mysql_ip_column');
+    if (savedIpCol) document.getElementById('mysqlIpCol').value = savedIpCol;
+
     const savedRange = localStorage.getItem('mysql_date_range') || 'today';
     document.getElementById('dateRange').value = savedRange;
     applyDateRange(true);
@@ -134,6 +137,7 @@ async function fetchMySQL() {
 
     // Remember selections for next visit
     localStorage.setItem('mysql_table', table);
+    localStorage.setItem('mysql_ip_column', col);
     localStorage.setItem('mysql_date_range', range);
     localStorage.setItem('mysql_start_time', start);
     localStorage.setItem('mysql_end_time', end);

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -60,10 +60,11 @@
 </div>
 <script>
 function setDateInput(elem, d) {
-    // valueAsNumber expects milliseconds since epoch in UTC but represents the
-    // value in the user's local timezone. Passing the raw timestamp avoids
-    // double-applying the timezone offset.
-    elem.valueAsNumber = d.getTime();
+    // Format the date in the user's local timezone so the displayed
+    // value matches the expected local time regardless of offset.
+    const offsetMs = d.getTimezoneOffset() * 60000;
+    const localISO = new Date(d.getTime() - offsetMs).toISOString().slice(0, 16);
+    elem.value = localISO;
 }
 
 function applyDateRange() {

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -53,6 +53,7 @@
             <div class="progress-bar" id="mysqlProgressBar" style="width:0%;"></div>
         </div>
         <div id="mysqlProgressText" class="mt-1"></div>
+        <pre id="mysqlLog" class="bg-dark text-white p-2 mt-2" style="display:none; height:200px; overflow:auto; font-size:0.9rem;"></pre>
     </div>
     {% else %}
     <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
@@ -137,9 +138,12 @@ async function fetchMySQL() {
     const progress = document.getElementById('mysqlProgress');
     const bar = document.getElementById('mysqlProgressBar');
     const text = document.getElementById('mysqlProgressText');
+    const log = document.getElementById('mysqlLog');
     bar.style.width = '0%';
     progress.querySelector('.progress').style.display = 'block';
     text.textContent = 'Starting...';
+    log.style.display = 'block';
+    log.textContent = '';
 
     const response = await fetch('/fetch-mysql', {
         method: 'POST',
@@ -174,6 +178,9 @@ async function fetchMySQL() {
                     text.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
                 } else if (data.type === 'error') {
                     text.textContent = `Error: ${data.message}`;
+                } else if (data.type === 'log') {
+                    log.textContent += data.message + '\n';
+                    log.scrollTop = log.scrollHeight;
                 }
             }
         }

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -72,7 +72,7 @@ function setDateInput(elem, d) {
     elem.value = formatForDB(d);
 }
 
-function applyDateRange() {
+function applyDateRange(useSaved=false) {
     const range = document.getElementById('dateRange').value;
     const startInput = document.getElementById('mysqlStart');
     const endInput = document.getElementById('mysqlEnd');
@@ -98,6 +98,12 @@ function applyDateRange() {
         default:
             startInput.disabled = false;
             endInput.disabled = false;
+            if (useSaved) {
+                const savedStart = localStorage.getItem('mysql_start_time');
+                const savedEnd = localStorage.getItem('mysql_end_time');
+                if (savedStart) startInput.value = savedStart;
+                if (savedEnd) endInput.value = savedEnd;
+            }
             return;
     }
     setDateInput(startInput, start);
@@ -108,13 +114,29 @@ function applyDateRange() {
 
 document.getElementById('dateRange').addEventListener('change', applyDateRange);
 
+document.addEventListener('DOMContentLoaded', () => {
+    const savedTable = localStorage.getItem('mysql_table');
+    if (savedTable) document.getElementById('mysqlTable').value = savedTable;
+
+    const savedRange = localStorage.getItem('mysql_date_range') || 'today';
+    document.getElementById('dateRange').value = savedRange;
+    applyDateRange(true);
+});
+
 async function fetchMySQL() {
     const conn = document.getElementById('mysqlConn').value;
     const table = document.getElementById('mysqlTable').value;
     const col = document.getElementById('mysqlIpCol').value || 'client_ip';
     const start = document.getElementById('mysqlStart').value;
     const end = document.getElementById('mysqlEnd').value;
+    const range = document.getElementById('dateRange').value;
     if (!conn || !table) return;
+
+    // Remember selections for next visit
+    localStorage.setItem('mysql_table', table);
+    localStorage.setItem('mysql_date_range', range);
+    localStorage.setItem('mysql_start_time', start);
+    localStorage.setItem('mysql_end_time', end);
 
     const progress = document.getElementById('mysqlProgress');
     const bar = document.getElementById('mysqlProgressBar');

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -9,22 +9,8 @@
             <input type="text" id="settingsTable" class="form-control" placeholder="Table name">
         </div>
         <div class="col-md-4">
-            <label class="form-label">Default date range</label>
-            <select id="settingsRange" class="form-select">
-                <option value="today">Today</option>
-                <option value="yesterday">Yesterday</option>
-                <option value="last7">Last 7 Days</option>
-                <option value="last30">Last 30 Days</option>
-                <option value="custom">Custom</option>
-            </select>
-        </div>
-        <div class="col-md-4">
-            <label class="form-label">Start time</label>
-            <input type="text" id="settingsStart" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
-        </div>
-        <div class="col-md-4">
-            <label class="form-label">End time</label>
-            <input type="text" id="settingsEnd" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
+            <label class="form-label">Default IP column</label>
+            <input type="text" id="settingsIpCol" class="form-control" placeholder="client_ip">
         </div>
     </div>
     <div class="row g-2 mb-2">
@@ -36,18 +22,13 @@
 <script>
 function saveSettings() {
     localStorage.setItem('mysql_table', document.getElementById('settingsTable').value);
-    const range = document.getElementById('settingsRange').value;
-    localStorage.setItem('mysql_date_range', range);
-    localStorage.setItem('mysql_start_time', document.getElementById('settingsStart').value);
-    localStorage.setItem('mysql_end_time', document.getElementById('settingsEnd').value);
+    localStorage.setItem('mysql_ip_column', document.getElementById('settingsIpCol').value);
     alert('Settings saved');
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('settingsTable').value = localStorage.getItem('mysql_table') || '';
-    document.getElementById('settingsRange').value = localStorage.getItem('mysql_date_range') || 'today';
-    document.getElementById('settingsStart').value = localStorage.getItem('mysql_start_time') || '';
-    document.getElementById('settingsEnd').value = localStorage.getItem('mysql_end_time') || '';
+    document.getElementById('settingsIpCol').value = localStorage.getItem('mysql_ip_column') || 'client_ip';
 });
 </script>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,48 +3,64 @@
 {% block content %}
 <h1 class="mb-4">⚙️ Settings</h1>
 
-<form method="post" class="card p-4 shadow-sm mb-4">
-    <h5 class="mb-3">MySQL Defaults</h5>
-    <div class="row g-3 mb-3">
-        <div class="col-md-4">
-            <label class="form-label">Default table</label>
-            <input type="text" name="default_table" class="form-control" placeholder="Table name" value="{{ default_table }}">
+<form method="post">
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">MySQL Defaults</h5>
         </div>
-        <div class="col-md-4">
-            <label class="form-label">Default IP column</label>
-            <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
-        </div>
-    </div>
-
-    <h5 class="mb-3">Dynamic IP Classification</h5>
-    <div class="row g-3 mb-3">
-        <div class="col-md-4">
-            <label class="form-label">High traffic threshold</label>
-            <input type="number" name="high_traffic_threshold" class="form-control" value="{{ high_traffic_threshold }}">
-        </div>
-        <div class="col-md-4">
-            <label class="form-label">Subnet IP threshold</label>
-            <input type="number" name="subnet_ip_threshold" class="form-control" value="{{ subnet_ip_threshold }}">
-        </div>
-        <div class="col-md-4">
-            <label class="form-label">Subnet view threshold</label>
-            <input type="number" name="subnet_view_threshold" class="form-control" value="{{ subnet_view_threshold }}">
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">Default table</label>
+                    <input type="text" name="default_table" class="form-control" placeholder="Table name" value="{{ default_table }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Default IP column</label>
+                    <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
+                </div>
+            </div>
         </div>
     </div>
 
-    <div class="row g-2 mb-2">
-        <div class="col-md-2 ms-auto">
-            <button type="submit" class="btn btn-primary w-100">Save</button>
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Dynamic IP Classification</h5>
         </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">High traffic threshold</label>
+                    <input type="number" name="high_traffic_threshold" class="form-control" value="{{ high_traffic_threshold }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Subnet IP threshold</label>
+                    <input type="number" name="subnet_ip_threshold" class="form-control" value="{{ subnet_ip_threshold }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Subnet view threshold</label>
+                    <input type="number" name="subnet_view_threshold" class="form-control" value="{{ subnet_view_threshold }}">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="text-end mb-4">
+        <button type="submit" class="btn btn-primary">Save</button>
     </div>
 </form>
 
-<div class="card p-4 shadow-sm bg-light border border-danger">
-    <h3>⚠️ Danger Zone</h3>
-    <p>Fix problematic cache entries or clean all data (cleaning cannot be undone!)</p>
-    <button onclick="fixCache()" class="btn btn-success me-2">Fix Unknown/Error IPs ({{ unknown_count + error_count }})</button>
-    <button onclick="cleanCache()" class="btn btn-danger me-2">Clean All Cache ({{ total_ips }} records)</button>
-    <button onclick="cleanResults()" class="btn btn-danger">Clean All Processed Files</button>
+<div class="card shadow-sm mb-4 border-danger">
+    <div class="card-header bg-danger text-white">
+        <h5 class="mb-0">⚠️ Danger Zone</h5>
+    </div>
+    <div class="card-body">
+        <p class="mb-3">Fix problematic cache entries or clean all data (cleaning cannot be undone!)</p>
+        <div class="d-flex flex-wrap gap-2">
+            <button onclick="fixCache()" class="btn btn-success">Fix Unknown/Error IPs ({{ unknown_count + error_count }})</button>
+            <button onclick="cleanCache()" class="btn btn-danger">Clean All Cache ({{ total_ips }} records)</button>
+            <button onclick="cleanResults()" class="btn btn-danger">Clean All Processed Files</button>
+        </div>
+    </div>
 </div>
 
 <script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2,8 +2,10 @@
 {% block title %}Settings{% endblock %}
 {% block content %}
 <h1 class="mb-4">⚙️ Settings</h1>
-<form method="post" class="card p-4 shadow-sm">
-    <div class="row g-3 mb-2">
+
+<form method="post" class="card p-4 shadow-sm mb-4">
+    <h5 class="mb-3">MySQL Defaults</h5>
+    <div class="row g-3 mb-3">
         <div class="col-md-4">
             <label class="form-label">Default table</label>
             <input type="text" name="default_table" class="form-control" placeholder="Table name" value="{{ default_table }}">
@@ -13,7 +15,9 @@
             <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
         </div>
     </div>
-    <div class="row g-3 mb-2">
+
+    <h5 class="mb-3">Dynamic IP Classification</h5>
+    <div class="row g-3 mb-3">
         <div class="col-md-4">
             <label class="form-label">High traffic threshold</label>
             <input type="number" name="high_traffic_threshold" class="form-control" value="{{ high_traffic_threshold }}">
@@ -27,10 +31,79 @@
             <input type="number" name="subnet_view_threshold" class="form-control" value="{{ subnet_view_threshold }}">
         </div>
     </div>
+
     <div class="row g-2 mb-2">
         <div class="col-md-2 ms-auto">
             <button type="submit" class="btn btn-primary w-100">Save</button>
         </div>
     </div>
 </form>
+
+<div class="card p-4 shadow-sm bg-light border border-danger">
+    <h3>⚠️ Danger Zone</h3>
+    <p>Fix problematic cache entries or clean all data (cleaning cannot be undone!)</p>
+    <button onclick="fixCache()" class="btn btn-success me-2">Fix Unknown/Error IPs ({{ unknown_count + error_count }})</button>
+    <button onclick="cleanCache()" class="btn btn-danger me-2">Clean All Cache ({{ total_ips }} records)</button>
+    <button onclick="cleanResults()" class="btn btn-danger">Clean All Processed Files</button>
+</div>
+
+<script>
+    async function cleanCache() {
+        if (!confirm('Are you sure you want to delete ALL cached IP data? This cannot be undone!')) return;
+
+        try {
+            const response = await fetch('/clean-cache', { method: 'POST' });
+            if (response.ok) {
+                alert('Cache cleaned successfully!');
+                location.reload();
+            } else {
+                const error = await response.json();
+                alert(`Error: ${error.error}`);
+            }
+        } catch (error) {
+            alert(`Error: ${error.message}`);
+        }
+    }
+
+    async function fixCache() {
+        if (!confirm('This will re-lookup all IPs with Unknown/Error data. Continue?')) return;
+
+        const btn = event.target;
+        btn.disabled = true;
+        btn.textContent = 'Fixing...';
+
+        try {
+            const response = await fetch('/fix-cache', { method: 'POST' });
+            const data = await response.json();
+
+            if (response.ok) {
+                alert(`Fixed ${data.fixed} out of ${data.total} problematic IPs!`);
+                location.reload();
+            } else {
+                alert(`Error: ${data.error}`);
+            }
+        } catch (error) {
+            alert(`Error: ${error.message}`);
+        } finally {
+            btn.disabled = false;
+            btn.textContent = 'Fix Unknown/Error IPs';
+        }
+    }
+
+    async function cleanResults() {
+        if (!confirm('Are you sure you want to delete ALL processed files? This cannot be undone!')) return;
+
+        try {
+            const response = await fetch('/clean-results', { method: 'POST' });
+            if (response.ok) {
+                alert('Processed files cleaned successfully!');
+            } else {
+                const error = await response.json();
+                alert(`Error: ${error.error}`);
+            }
+        } catch (error) {
+            alert(`Error: ${error.message}`);
+        }
+    }
+</script>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+{% block title %}Settings{% endblock %}
+{% block content %}
+<h1 class="mb-4">⚙️ Settings</h1>
+<div class="card p-4 shadow-sm">
+    <div class="row g-3 mb-2">
+        <div class="col-md-4">
+            <label class="form-label">Default table</label>
+            <input type="text" id="settingsTable" class="form-control" placeholder="Table name">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Default date range</label>
+            <select id="settingsRange" class="form-select">
+                <option value="today">Today</option>
+                <option value="yesterday">Yesterday</option>
+                <option value="last7">Last 7 Days</option>
+                <option value="last30">Last 30 Days</option>
+                <option value="custom">Custom</option>
+            </select>
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Start time</label>
+            <input type="text" id="settingsStart" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">End time</label>
+            <input type="text" id="settingsEnd" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
+        </div>
+    </div>
+    <div class="row g-2 mb-2">
+        <div class="col-md-2 ms-auto">
+            <button class="btn btn-primary w-100" onclick="saveSettings()">Save</button>
+        </div>
+    </div>
+</div>
+<script>
+function saveSettings() {
+    localStorage.setItem('mysql_table', document.getElementById('settingsTable').value);
+    const range = document.getElementById('settingsRange').value;
+    localStorage.setItem('mysql_date_range', range);
+    localStorage.setItem('mysql_start_time', document.getElementById('settingsStart').value);
+    localStorage.setItem('mysql_end_time', document.getElementById('settingsEnd').value);
+    alert('Settings saved');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('settingsTable').value = localStorage.getItem('mysql_table') || '';
+    document.getElementById('settingsRange').value = localStorage.getItem('mysql_date_range') || 'today';
+    document.getElementById('settingsStart').value = localStorage.getItem('mysql_start_time') || '';
+    document.getElementById('settingsEnd').value = localStorage.getItem('mysql_end_time') || '';
+});
+</script>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2,33 +2,21 @@
 {% block title %}Settings{% endblock %}
 {% block content %}
 <h1 class="mb-4">⚙️ Settings</h1>
-<div class="card p-4 shadow-sm">
+<form method="post" class="card p-4 shadow-sm">
     <div class="row g-3 mb-2">
         <div class="col-md-4">
             <label class="form-label">Default table</label>
-            <input type="text" id="settingsTable" class="form-control" placeholder="Table name">
+            <input type="text" name="default_table" class="form-control" placeholder="Table name" value="{{ default_table }}">
         </div>
         <div class="col-md-4">
             <label class="form-label">Default IP column</label>
-            <input type="text" id="settingsIpCol" class="form-control" placeholder="client_ip">
+            <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
         </div>
     </div>
     <div class="row g-2 mb-2">
         <div class="col-md-2 ms-auto">
-            <button class="btn btn-primary w-100" onclick="saveSettings()">Save</button>
+            <button type="submit" class="btn btn-primary w-100">Save</button>
         </div>
     </div>
-</div>
-<script>
-function saveSettings() {
-    localStorage.setItem('mysql_table', document.getElementById('settingsTable').value);
-    localStorage.setItem('mysql_ip_column', document.getElementById('settingsIpCol').value);
-    alert('Settings saved');
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-    document.getElementById('settingsTable').value = localStorage.getItem('mysql_table') || '';
-    document.getElementById('settingsIpCol').value = localStorage.getItem('mysql_ip_column') || 'client_ip';
-});
-</script>
+</form>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -13,6 +13,20 @@
             <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
         </div>
     </div>
+    <div class="row g-3 mb-2">
+        <div class="col-md-4">
+            <label class="form-label">High traffic threshold</label>
+            <input type="number" name="high_traffic_threshold" class="form-control" value="{{ high_traffic_threshold }}">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Subnet IP threshold</label>
+            <input type="number" name="subnet_ip_threshold" class="form-control" value="{{ subnet_ip_threshold }}">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Subnet view threshold</label>
+            <input type="number" name="subnet_view_threshold" class="form-control" value="{{ subnet_view_threshold }}">
+        </div>
+    </div>
     <div class="row g-2 mb-2">
         <div class="col-md-2 ms-auto">
             <button type="submit" class="btn btn-primary w-100">Save</button>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -14,8 +14,6 @@
     a { color: #007cba; text-decoration: none; }
     a:hover { text-decoration: underline; }
     .nav-links { display: flex; gap: 15px; }
-    .clean-section { margin: 30px 0; }
-    .clean-btn { margin: 5px; }
 </style>
 {% endblock %}
 {% block content %}
@@ -71,71 +69,5 @@
     </div>
 </div>
 
-<div class="clean-section card p-4 shadow-sm bg-light border border-danger">
-    <h3>⚠️ Danger Zone</h3>
-    <p>Fix problematic cache entries or clean all data (cleaning cannot be undone!)</p>
-    <button onclick="fixCache()" class="btn btn-success clean-btn">Fix Unknown/Error IPs</button>
-    <button onclick="cleanCache()" class="btn btn-danger clean-btn">Clean All Cache ({{ total_ips }} records)</button>
-    <button onclick="cleanResults()" class="btn btn-danger clean-btn">Clean All Processed Files</button>
-</div>
 
-<script>
-    async function cleanCache() {
-        if (!confirm('Are you sure you want to delete ALL cached IP data? This cannot be undone!')) return;
-
-        try {
-            const response = await fetch('/clean-cache', { method: 'POST' });
-            if (response.ok) {
-                alert('Cache cleaned successfully!');
-                location.reload();
-            } else {
-                const error = await response.json();
-                alert(`Error: ${error.error}`);
-            }
-        } catch (error) {
-            alert(`Error: ${error.message}`);
-        }
-    }
-
-    async function fixCache() {
-        if (!confirm('This will re-lookup all IPs with Unknown/Error data. Continue?')) return;
-
-        const btn = event.target;
-        btn.disabled = true;
-        btn.textContent = 'Fixing...';
-
-        try {
-            const response = await fetch('/fix-cache', { method: 'POST' });
-            const data = await response.json();
-
-            if (response.ok) {
-                alert(`Fixed ${data.fixed} out of ${data.total} problematic IPs!`);
-                location.reload();
-            } else {
-                alert(`Error: ${data.error}`);
-            }
-        } catch (error) {
-            alert(`Error: ${error.message}`);
-        } finally {
-            btn.disabled = false;
-            btn.textContent = 'Fix Unknown/Error IPs';
-        }
-    }
-
-    async function cleanResults() {
-        if (!confirm('Are you sure you want to delete ALL processed files? This cannot be undone!')) return;
-
-        try {
-            const response = await fetch('/clean-results', { method: 'POST' });
-            if (response.ok) {
-                alert('Processed files cleaned successfully!');
-            } else {
-                const error = await response.json();
-                alert(`Error: ${error.error}`);
-            }
-        } catch (error) {
-            alert(`Error: ${error.message}`);
-        }
-    }
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow storing MySQL connections in `ip_cache.db`
- add management routes and UI for MySQL connections
- allow fetching IPs from a MySQL table and generating results
- show MySQL section on home page
- document MySQL features and add `pymysql` dependency

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68675bc46ee0832da7ab74a989f8bd38