### PR TITLE
Separate MySQL lookup into its own page

### DIFF
--- a/app.py
+++ b/app.py
@@ -255,13 +255,18 @@ def get_ip_location(ip, use_delay=False):
 
 @app.route('/')
 def index():
+    return render_template('index.html')
+
+
+@app.route('/mysql-lookup')
+def mysql_lookup_page():
     conn = sqlite3.connect(DB_FILE)
     conn.row_factory = sqlite3.Row
     connections = conn.execute(
         'SELECT id, name, database FROM mysql_connections'
     ).fetchall()
     conn.close()
-    return render_template('index.html', mysql_connections=connections)
+    return render_template('mysql_lookup.html', mysql_connections=connections)
 
 
 @app.route('/stats')

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('view_stats') }}"><i class="bi bi-bar-chart"></i> Statistics</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('view_cache') }}"><i class="bi bi-hdd"></i> Cache</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('list_results') }}"><i class="bi bi-folder2-open"></i> Files</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('mysql_lookup_page') }}"><i class="bi bi-search"></i> DB Lookup</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('manage_connections') }}"><i class="bi bi-database"></i> MySQL</a></li>
                 </ul>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,30 +20,6 @@
     <div id="result"></div>
 </div>
 
-<div class="section card p-4 shadow-sm">
-    <h3 class="mb-3">MySQL Table Lookup</h3>
-    {% if mysql_connections %}
-    <div class="row g-2 mb-2">
-        <div class="col-md-3">
-            <select id="mysqlConn" class="form-select">
-                {% for c in mysql_connections %}
-                    <option value="{{ c['id'] }}">{{ c['name'] }} ({{ c['database'] }})</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="col-md-3"><input type="text" id="mysqlTable" class="form-control" placeholder="Table"/></div>
-        <div class="col-md-2"><input type="text" id="mysqlIpCol" class="form-control" value="client_ip" placeholder="IP column"/></div>
-        <div class="col-md-2"><input type="datetime-local" id="mysqlStart" class="form-control"/></div>
-        <div class="col-md-2"><input type="datetime-local" id="mysqlEnd" class="form-control"/></div>
-    </div>
-    <div class="row g-2 mb-2">
-        <div class="col-md-2 ms-auto"><button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button></div>
-    </div>
-    <div id="mysqlProgress" class="mt-2"></div>
-    {% else %}
-    <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
-    {% endif %}
-</div>
 
 <div class="section card p-4 shadow-sm">
     <h3 class="mb-3">CSV File Processing</h3>
@@ -224,51 +200,5 @@
         return `${minutes}m ${remainingSeconds}s`;
     }
 
-    async function fetchMySQL() {
-        const conn = document.getElementById('mysqlConn').value;
-        const table = document.getElementById('mysqlTable').value;
-        const col = document.getElementById('mysqlIpCol').value || 'client_ip';
-        const start = document.getElementById('mysqlStart').value;
-        const end = document.getElementById('mysqlEnd').value;
-        if (!conn || !table) return;
-
-        const progress = document.getElementById('mysqlProgress');
-        progress.textContent = 'Starting...';
-
-        const response = await fetch('/fetch-mysql', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({
-                connection_id: conn,
-                table: table,
-                ip_column: col,
-                start_time: start ? start.replace('T', ' ') + ':00' : null,
-                end_time: end ? end.replace('T', ' ') + ':00' : null
-            })
-        });
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        while (true) {
-            const {done, value} = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, {stream:true});
-            const lines = buffer.split('\n');
-            buffer = lines.pop();
-            for (const line of lines) {
-                if (line.startsWith('data: ')) {
-                    const data = JSON.parse(line.slice(6));
-                    if (data.type === 'progress') {
-                        progress.textContent = `${data.processed}/${data.total} IPs processed`;
-                    } else if (data.type === 'complete') {
-                        progress.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
-                    } else if (data.type === 'error') {
-                        progress.textContent = `Error: ${data.message}`;
-                    }
-                }
-            }
-        }
-    }
 </script>
 {% endblock %}

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -1,0 +1,92 @@
+{% extends 'base.html' %}
+{% block title %}MySQL Table Lookup{% endblock %}
+{% block content %}
+<h1 class="mb-4">🔍 MySQL Table Lookup</h1>
+<div class="card p-4 shadow-sm">
+    {% if mysql_connections %}
+    <p>Select a connection and table to fetch unique IPs with location data.</p>
+    <div class="row g-3 mb-2">
+        <div class="col-md-3">
+            <label class="form-label">Connection</label>
+            <select id="mysqlConn" class="form-select">
+                {% for c in mysql_connections %}
+                    <option value="{{ c['id'] }}">{{ c['name'] }} ({{ c['database'] }})</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">Table</label>
+            <input type="text" id="mysqlTable" class="form-control" placeholder="Table name">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">IP column</label>
+            <input type="text" id="mysqlIpCol" class="form-control" value="client_ip">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Start time</label>
+            <input type="datetime-local" id="mysqlStart" class="form-control">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">End time</label>
+            <input type="datetime-local" id="mysqlEnd" class="form-control">
+        </div>
+    </div>
+    <div class="row g-2 mb-2">
+        <div class="col-md-2 ms-auto">
+            <button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button>
+        </div>
+    </div>
+    <div id="mysqlProgress" class="mt-2"></div>
+    {% else %}
+    <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
+    {% endif %}
+</div>
+<script>
+async function fetchMySQL() {
+    const conn = document.getElementById('mysqlConn').value;
+    const table = document.getElementById('mysqlTable').value;
+    const col = document.getElementById('mysqlIpCol').value || 'client_ip';
+    const start = document.getElementById('mysqlStart').value;
+    const end = document.getElementById('mysqlEnd').value;
+    if (!conn || !table) return;
+
+    const progress = document.getElementById('mysqlProgress');
+    progress.textContent = 'Starting...';
+
+    const response = await fetch('/fetch-mysql', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            connection_id: conn,
+            table: table,
+            ip_column: col,
+            start_time: start ? start.replace('T', ' ') + ':00' : null,
+            end_time: end ? end.replace('T', ' ') + ':00' : null
+        })
+    });
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, {stream:true});
+        const lines = buffer.split('\n');
+        buffer = lines.pop();
+        for (const line of lines) {
+            if (line.startsWith('data: ')) {
+                const data = JSON.parse(line.slice(6));
+                if (data.type === 'progress') {
+                    progress.textContent = `${data.processed}/${data.total} IPs processed`;
+                } else if (data.type === 'complete') {
+                    progress.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
+                } else if (data.type === 'error') {
+                    progress.textContent = `Error: ${data.message}`;
+                }
+            }
+        }
+    }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- remove MySQL table lookup section from the home page
- add dedicated `/mysql-lookup` route and template
- add navigation link for DB lookup
- simplify index route

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689834f51c832db073d2f5896b4252