### PR TITLE
Improve MySQL lookup usability

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -17,3 +17,7 @@ a {
 .likely-fake-row>th {
     background-color: #ed8b8b !important;
 }
+
+#mysqlProgress {
+    max-width: 400px;
+}

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -36,11 +36,11 @@
         </div>
         <div class="col-md-4">
             <label class="form-label">Start time</label>
-            <input type="datetime-local" id="mysqlStart" class="form-control">
+            <input type="text" id="mysqlStart" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
         </div>
         <div class="col-md-4">
             <label class="form-label">End time</label>
-            <input type="datetime-local" id="mysqlEnd" class="form-control">
+            <input type="text" id="mysqlEnd" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
         </div>
     </div>
     <div class="row g-2 mb-2">
@@ -59,12 +59,17 @@
     {% endif %}
 </div>
 <script>
-function setDateInput(elem, d) {
-    // Format the date in the user's local timezone so the displayed
-    // value matches the expected local time regardless of offset.
+function formatForDB(d) {
+    // Convert a Date to YYYY-MM-DD HH:MM:SS in the browser's local timezone
     const offsetMs = d.getTimezoneOffset() * 60000;
-    const localISO = new Date(d.getTime() - offsetMs).toISOString().slice(0, 16);
-    elem.value = localISO;
+    return new Date(d.getTime() - offsetMs)
+        .toISOString()
+        .slice(0, 19)
+        .replace('T', ' ');
+}
+
+function setDateInput(elem, d) {
+    elem.value = formatForDB(d);
 }
 
 function applyDateRange() {
@@ -125,8 +130,8 @@ async function fetchMySQL() {
             connection_id: conn,
             table: table,
             ip_column: col,
-            start_time: start ? start.replace('T', ' ') + ':00' : null,
-            end_time: end ? end.replace('T', ' ') + ':00' : null
+            start_time: start || null,
+            end_time: end || null
         })
     });
 

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -60,9 +60,8 @@
 </div>
 <script>
 function toInputValue(d) {
-    const pad = n => n.toString().padStart(2, '0');
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
-        `T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+    return local.toISOString().slice(0, 16);
 }
 
 function applyDateRange() {

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -6,7 +6,7 @@
     {% if mysql_connections %}
     <p>Select a connection and table to fetch unique IPs with location data.</p>
     <div class="row g-3 mb-2">
-        <div class="col-md-3">
+        <div class="col-md-4">
             <label class="form-label">Connection</label>
             <select id="mysqlConn" class="form-select">
                 {% for c in mysql_connections %}
@@ -14,19 +14,31 @@
                 {% endfor %}
             </select>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-4">
             <label class="form-label">Table</label>
             <input type="text" id="mysqlTable" class="form-control" placeholder="Table name">
         </div>
-        <div class="col-md-2">
+        <div class="col-md-4">
             <label class="form-label">IP column</label>
             <input type="text" id="mysqlIpCol" class="form-control" value="client_ip">
         </div>
-        <div class="col-md-2">
+    </div>
+    <div class="row g-3 mb-2">
+        <div class="col-md-4">
+            <label class="form-label">Date range</label>
+            <select id="dateRange" class="form-select">
+                <option value="custom">Custom</option>
+                <option value="today">Today</option>
+                <option value="yesterday">Yesterday</option>
+                <option value="last7">Last 7 Days</option>
+                <option value="last30">Last 30 Days</option>
+            </select>
+        </div>
+        <div class="col-md-4">
             <label class="form-label">Start time</label>
             <input type="datetime-local" id="mysqlStart" class="form-control">
         </div>
-        <div class="col-md-2">
+        <div class="col-md-4">
             <label class="form-label">End time</label>
             <input type="datetime-local" id="mysqlEnd" class="form-control">
         </div>
@@ -36,12 +48,52 @@
             <button class="btn btn-primary w-100" onclick="fetchMySQL()">Fetch</button>
         </div>
     </div>
-    <div id="mysqlProgress" class="mt-2"></div>
-    {% else %}
+    <div id="mysqlProgress" class="mt-2">
+        <div class="progress" style="display:none; height:20px;">
+            <div class="progress-bar" id="mysqlProgressBar" style="width:0%;"></div>
+        </div>
+        <div id="mysqlProgressText" class="mt-1"></div>
+    </div>
     <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
     {% endif %}
 </div>
 <script>
+function applyDateRange() {
+    const range = document.getElementById('dateRange').value;
+    const startInput = document.getElementById('mysqlStart');
+    const endInput = document.getElementById('mysqlEnd');
+    const now = new Date();
+    let start, end;
+    switch(range) {
+        case 'today':
+            start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+            end = new Date(start.getTime() + 86400000);
+            break;
+        case 'yesterday':
+            start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
+            end = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+            break;
+        case 'last7':
+            start = new Date(now.getTime() - 7*86400000);
+            end = now;
+            break;
+        case 'last30':
+            start = new Date(now.getTime() - 30*86400000);
+            end = now;
+            break;
+        default:
+            startInput.disabled = false;
+            endInput.disabled = false;
+            return;
+    }
+    startInput.value = start.toISOString().slice(0,16);
+    endInput.value = end.toISOString().slice(0,16);
+    startInput.disabled = true;
+    endInput.disabled = true;
+}
+
+document.getElementById('dateRange').addEventListener('change', applyDateRange);
+
 async function fetchMySQL() {
     const conn = document.getElementById('mysqlConn').value;
     const table = document.getElementById('mysqlTable').value;
@@ -51,7 +103,11 @@ async function fetchMySQL() {
     if (!conn || !table) return;
 
     const progress = document.getElementById('mysqlProgress');
-    progress.textContent = 'Starting...';
+    const bar = document.getElementById('mysqlProgressBar');
+    const text = document.getElementById('mysqlProgressText');
+    bar.style.width = '0%';
+    progress.querySelector('.progress').style.display = 'block';
+    text.textContent = 'Starting...';
 
     const response = await fetch('/fetch-mysql', {
         method: 'POST',
@@ -78,11 +134,14 @@ async function fetchMySQL() {
             if (line.startsWith('data: ')) {
                 const data = JSON.parse(line.slice(6));
                 if (data.type === 'progress') {
-                    progress.textContent = `${data.processed}/${data.total} IPs processed`;
+                    const pct = Math.round(data.processed / data.total * 100);
+                    bar.style.width = pct + '%';
+                    text.textContent = `${data.processed}/${data.total} IPs`;
                 } else if (data.type === 'complete') {
-                    progress.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
+                    bar.style.width = '100%';
+                    text.innerHTML = `Done! <a href="/view/${data.filename}">${data.filename}</a>`;
                 } else if (data.type === 'error') {
-                    progress.textContent = `Error: ${data.message}`;
+                    text.textContent = `Error: ${data.message}`;
                 }
             }
         }

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -54,6 +54,7 @@
         </div>
         <div id="mysqlProgressText" class="mt-1"></div>
     </div>
+    {% else %}
     <p>No MySQL connections configured. <a href="{{ url_for('manage_connections') }}">Add one</a>.</p>
     {% endif %}
 </div>
@@ -67,7 +68,7 @@ function applyDateRange() {
     switch(range) {
         case 'today':
             start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-            end = new Date(start.getTime() + 86400000);
+            end = now;
             break;
         case 'yesterday':
             start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -59,6 +59,12 @@
     {% endif %}
 </div>
 <script>
+function toInputValue(d) {
+    const pad = n => n.toString().padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+        `T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 function applyDateRange() {
     const range = document.getElementById('dateRange').value;
     const startInput = document.getElementById('mysqlStart');
@@ -87,8 +93,8 @@ function applyDateRange() {
             endInput.disabled = false;
             return;
     }
-    startInput.value = start.toISOString().slice(0,16);
-    endInput.value = end.toISOString().slice(0,16);
+    startInput.value = toInputValue(start);
+    endInput.value = toInputValue(end);
     startInput.disabled = true;
     endInput.disabled = true;
 }

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -60,7 +60,10 @@
 </div>
 <script>
 function setDateInput(elem, d) {
-    elem.valueAsNumber = d.getTime() - d.getTimezoneOffset() * 60000;
+    // valueAsNumber expects milliseconds since epoch in UTC but represents the
+    // value in the user's local timezone. Passing the raw timestamp avoids
+    // double-applying the timezone offset.
+    elem.valueAsNumber = d.getTime();
 }
 
 function applyDateRange() {

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -59,9 +59,8 @@
     {% endif %}
 </div>
 <script>
-function toInputValue(d) {
-    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-    return local.toISOString().slice(0, 16);
+function setDateInput(elem, d) {
+    elem.valueAsNumber = d.getTime() - d.getTimezoneOffset() * 60000;
 }
 
 function applyDateRange() {
@@ -92,8 +91,8 @@ function applyDateRange() {
             endInput.disabled = false;
             return;
     }
-    startInput.value = toInputValue(start);
-    endInput.value = toInputValue(end);
+    setDateInput(startInput, start);
+    setDateInput(endInput, end);
     startInput.disabled = true;
     endInput.disabled = true;
 }

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -60,10 +60,11 @@
 </div>
 <script>
 function setDateInput(elem, d) {
-    // valueAsNumber expects milliseconds since epoch in UTC but represents the
-    // value in the user's local timezone. Passing the raw timestamp avoids
-    // double-applying the timezone offset.
-    elem.valueAsNumber = d.getTime();
+    // Format the date in the user's local timezone so the displayed
+    // value matches the expected local time regardless of offset.
+    const offsetMs = d.getTimezoneOffset() * 60000;
+    const localISO = new Date(d.getTime() - offsetMs).toISOString().slice(0, 16);
+    elem.value = localISO;
 }
 
 function applyDateRange() {


### PR DESCRIPTION
## Summary
- add date range selector and progress bar to MySQL lookup page
- wire up JavaScript to populate date fields and show progress
- tweak styling for progress section

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68689b2dffc8832d8b86bd3c0ce229ad