### PR TITLE
Remember MySQL lookup options

### DIFF
--- a/app.py
+++ b/app.py
@@ -629,13 +629,6 @@ def fetch_mysql():
             mimetype='text/event-stream',
         )
 
-    settings_conn = sqlite3.connect(DB_FILE)
-    settings_conn.execute(
-        'UPDATE app_settings SET default_table=?, default_ip_column=? WHERE id=1',
-        (table, ip_column),
-    )
-    settings_conn.commit()
-    settings_conn.close()
 
     def generate():
         db_conn = sqlite3.connect(DB_FILE)

--- a/app.py
+++ b/app.py
@@ -54,6 +54,19 @@ def init_db():
         """
     )
 
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS app_settings (
+            id INTEGER PRIMARY KEY CHECK(id = 1),
+            default_table TEXT,
+            default_ip_column TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO app_settings (id, default_table, default_ip_column) VALUES (1, '', 'client_ip')"
+    )
+
     # List of required columns and their SQLite types
     required_columns = {
         "status": "TEXT",
@@ -265,14 +278,44 @@ def mysql_lookup_page():
     connections = conn.execute(
         'SELECT id, name, database FROM mysql_connections'
     ).fetchall()
+    settings_row = conn.execute(
+        'SELECT default_table, default_ip_column FROM app_settings WHERE id=1'
+    ).fetchone()
     conn.close()
-    return render_template('mysql_lookup.html', mysql_connections=connections)
+    default_table = settings_row['default_table'] if settings_row else ''
+    default_ip_col = settings_row['default_ip_column'] if settings_row else 'client_ip'
+    return render_template(
+        'mysql_lookup.html',
+        mysql_connections=connections,
+        default_table=default_table,
+        default_ip_col=default_ip_col,
+    )
 
 
-@app.route('/settings')
+@app.route('/settings', methods=['GET', 'POST'])
 def settings_page():
-    """Render the preferences page for MySQL lookup defaults."""
-    return render_template('settings.html')
+    """Configure default table and IP column for MySQL lookups."""
+    conn = sqlite3.connect(DB_FILE)
+    if request.method == 'POST':
+        conn.execute(
+            'UPDATE app_settings SET default_table=?, default_ip_column=? WHERE id=1',
+            (
+                request.form.get('default_table', ''),
+                request.form.get('default_ip_column', 'client_ip'),
+            ),
+        )
+        conn.commit()
+    row = conn.execute(
+        'SELECT default_table, default_ip_column FROM app_settings WHERE id=1'
+    ).fetchone()
+    conn.close()
+    default_table = row[0] if row else ''
+    default_ip_col = row[1] if row else 'client_ip'
+    return render_template(
+        'settings.html',
+        default_table=default_table,
+        default_ip_col=default_ip_col,
+    )
 
 
 @app.route('/stats')
@@ -585,6 +628,14 @@ def fetch_mysql():
             f"data: {json.dumps({'type': 'error', 'message': 'Invalid end time'})}\n\n",
             mimetype='text/event-stream',
         )
+
+    settings_conn = sqlite3.connect(DB_FILE)
+    settings_conn.execute(
+        'UPDATE app_settings SET default_table=?, default_ip_column=? WHERE id=1',
+        (table, ip_column),
+    )
+    settings_conn.commit()
+    settings_conn.close()
 
     def generate():
         db_conn = sqlite3.connect(DB_FILE)

--- a/app.py
+++ b/app.py
@@ -269,6 +269,12 @@ def mysql_lookup_page():
     return render_template('mysql_lookup.html', mysql_connections=connections)
 
 
+@app.route('/settings')
+def settings_page():
+    """Render the preferences page for MySQL lookup defaults."""
+    return render_template('settings.html')
+
+
 @app.route('/stats')
 def view_stats():
     conn = sqlite3.connect(DB_FILE)

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,7 @@
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('list_results') }}"><i class="bi bi-folder2-open"></i> Files</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('mysql_lookup_page') }}"><i class="bi bi-search"></i> DB Lookup</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('manage_connections') }}"><i class="bi bi-database"></i> MySQL</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('settings_page') }}"><i class="bi bi-gear"></i> Settings</a></li>
                 </ul>
             </div>
         </div>

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -16,11 +16,11 @@
         </div>
         <div class="col-md-4">
             <label class="form-label">Table</label>
-            <input type="text" id="mysqlTable" class="form-control" placeholder="Table name">
+            <input type="text" id="mysqlTable" class="form-control" placeholder="Table name" value="{{ default_table }}">
         </div>
         <div class="col-md-4">
             <label class="form-label">IP column</label>
-            <input type="text" id="mysqlIpCol" class="form-control" value="client_ip">
+            <input type="text" id="mysqlIpCol" class="form-control" value="{{ default_ip_col }}">
         </div>
     </div>
     <div class="row g-3 mb-2">
@@ -115,12 +115,6 @@ function applyDateRange(useSaved=false) {
 document.getElementById('dateRange').addEventListener('change', applyDateRange);
 
 document.addEventListener('DOMContentLoaded', () => {
-    const savedTable = localStorage.getItem('mysql_table');
-    if (savedTable) document.getElementById('mysqlTable').value = savedTable;
-
-    const savedIpCol = localStorage.getItem('mysql_ip_column');
-    if (savedIpCol) document.getElementById('mysqlIpCol').value = savedIpCol;
-
     const savedRange = localStorage.getItem('mysql_date_range') || 'today';
     document.getElementById('dateRange').value = savedRange;
     applyDateRange(true);
@@ -136,8 +130,6 @@ async function fetchMySQL() {
     if (!conn || !table) return;
 
     // Remember selections for next visit
-    localStorage.setItem('mysql_table', table);
-    localStorage.setItem('mysql_ip_column', col);
     localStorage.setItem('mysql_date_range', range);
     localStorage.setItem('mysql_start_time', start);
     localStorage.setItem('mysql_end_time', end);

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -118,6 +118,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const savedTable = localStorage.getItem('mysql_table');
     if (savedTable) document.getElementById('mysqlTable').value = savedTable;
 
+    const savedIpCol = localStorage.getItem('mysql_ip_column');
+    if (savedIpCol) document.getElementById('mysqlIpCol').value = savedIpCol;
+
     const savedRange = localStorage.getItem('mysql_date_range') || 'today';
     document.getElementById('dateRange').value = savedRange;
     applyDateRange(true);
@@ -134,6 +137,7 @@ async function fetchMySQL() {
 
     // Remember selections for next visit
     localStorage.setItem('mysql_table', table);
+    localStorage.setItem('mysql_ip_column', col);
     localStorage.setItem('mysql_date_range', range);
     localStorage.setItem('mysql_start_time', start);
     localStorage.setItem('mysql_end_time', end);

--- a/templates/mysql_lookup.html
+++ b/templates/mysql_lookup.html
@@ -72,7 +72,7 @@ function setDateInput(elem, d) {
     elem.value = formatForDB(d);
 }
 
-function applyDateRange() {
+function applyDateRange(useSaved=false) {
     const range = document.getElementById('dateRange').value;
     const startInput = document.getElementById('mysqlStart');
     const endInput = document.getElementById('mysqlEnd');
@@ -98,6 +98,12 @@ function applyDateRange() {
         default:
             startInput.disabled = false;
             endInput.disabled = false;
+            if (useSaved) {
+                const savedStart = localStorage.getItem('mysql_start_time');
+                const savedEnd = localStorage.getItem('mysql_end_time');
+                if (savedStart) startInput.value = savedStart;
+                if (savedEnd) endInput.value = savedEnd;
+            }
             return;
     }
     setDateInput(startInput, start);
@@ -108,13 +114,29 @@ function applyDateRange() {
 
 document.getElementById('dateRange').addEventListener('change', applyDateRange);
 
+document.addEventListener('DOMContentLoaded', () => {
+    const savedTable = localStorage.getItem('mysql_table');
+    if (savedTable) document.getElementById('mysqlTable').value = savedTable;
+
+    const savedRange = localStorage.getItem('mysql_date_range') || 'today';
+    document.getElementById('dateRange').value = savedRange;
+    applyDateRange(true);
+});
+
 async function fetchMySQL() {
     const conn = document.getElementById('mysqlConn').value;
     const table = document.getElementById('mysqlTable').value;
     const col = document.getElementById('mysqlIpCol').value || 'client_ip';
     const start = document.getElementById('mysqlStart').value;
     const end = document.getElementById('mysqlEnd').value;
+    const range = document.getElementById('dateRange').value;
     if (!conn || !table) return;
+
+    // Remember selections for next visit
+    localStorage.setItem('mysql_table', table);
+    localStorage.setItem('mysql_date_range', range);
+    localStorage.setItem('mysql_start_time', start);
+    localStorage.setItem('mysql_end_time', end);
 
     const progress = document.getElementById('mysqlProgress');
     const bar = document.getElementById('mysqlProgressBar');

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -9,22 +9,8 @@
             <input type="text" id="settingsTable" class="form-control" placeholder="Table name">
         </div>
         <div class="col-md-4">
-            <label class="form-label">Default date range</label>
-            <select id="settingsRange" class="form-select">
-                <option value="today">Today</option>
-                <option value="yesterday">Yesterday</option>
-                <option value="last7">Last 7 Days</option>
-                <option value="last30">Last 30 Days</option>
-                <option value="custom">Custom</option>
-            </select>
-        </div>
-        <div class="col-md-4">
-            <label class="form-label">Start time</label>
-            <input type="text" id="settingsStart" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
-        </div>
-        <div class="col-md-4">
-            <label class="form-label">End time</label>
-            <input type="text" id="settingsEnd" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
+            <label class="form-label">Default IP column</label>
+            <input type="text" id="settingsIpCol" class="form-control" placeholder="client_ip">
         </div>
     </div>
     <div class="row g-2 mb-2">
@@ -36,18 +22,13 @@
 <script>
 function saveSettings() {
     localStorage.setItem('mysql_table', document.getElementById('settingsTable').value);
-    const range = document.getElementById('settingsRange').value;
-    localStorage.setItem('mysql_date_range', range);
-    localStorage.setItem('mysql_start_time', document.getElementById('settingsStart').value);
-    localStorage.setItem('mysql_end_time', document.getElementById('settingsEnd').value);
+    localStorage.setItem('mysql_ip_column', document.getElementById('settingsIpCol').value);
     alert('Settings saved');
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('settingsTable').value = localStorage.getItem('mysql_table') || '';
-    document.getElementById('settingsRange').value = localStorage.getItem('mysql_date_range') || 'today';
-    document.getElementById('settingsStart').value = localStorage.getItem('mysql_start_time') || '';
-    document.getElementById('settingsEnd').value = localStorage.getItem('mysql_end_time') || '';
+    document.getElementById('settingsIpCol').value = localStorage.getItem('mysql_ip_column') || 'client_ip';
 });
 </script>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+{% block title %}Settings{% endblock %}
+{% block content %}
+<h1 class="mb-4">⚙️ Settings</h1>
+<div class="card p-4 shadow-sm">
+    <div class="row g-3 mb-2">
+        <div class="col-md-4">
+            <label class="form-label">Default table</label>
+            <input type="text" id="settingsTable" class="form-control" placeholder="Table name">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Default date range</label>
+            <select id="settingsRange" class="form-select">
+                <option value="today">Today</option>
+                <option value="yesterday">Yesterday</option>
+                <option value="last7">Last 7 Days</option>
+                <option value="last30">Last 30 Days</option>
+                <option value="custom">Custom</option>
+            </select>
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Start time</label>
+            <input type="text" id="settingsStart" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">End time</label>
+            <input type="text" id="settingsEnd" class="form-control" placeholder="YYYY-MM-DD HH:MM:SS">
+        </div>
+    </div>
+    <div class="row g-2 mb-2">
+        <div class="col-md-2 ms-auto">
+            <button class="btn btn-primary w-100" onclick="saveSettings()">Save</button>
+        </div>
+    </div>
+</div>
+<script>
+function saveSettings() {
+    localStorage.setItem('mysql_table', document.getElementById('settingsTable').value);
+    const range = document.getElementById('settingsRange').value;
+    localStorage.setItem('mysql_date_range', range);
+    localStorage.setItem('mysql_start_time', document.getElementById('settingsStart').value);
+    localStorage.setItem('mysql_end_time', document.getElementById('settingsEnd').value);
+    alert('Settings saved');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('settingsTable').value = localStorage.getItem('mysql_table') || '';
+    document.getElementById('settingsRange').value = localStorage.getItem('mysql_date_range') || 'today';
+    document.getElementById('settingsStart').value = localStorage.getItem('mysql_start_time') || '';
+    document.getElementById('settingsEnd').value = localStorage.getItem('mysql_end_time') || '';
+});
+</script>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2,33 +2,21 @@
 {% block title %}Settings{% endblock %}
 {% block content %}
 <h1 class="mb-4">⚙️ Settings</h1>
-<div class="card p-4 shadow-sm">
+<form method="post" class="card p-4 shadow-sm">
     <div class="row g-3 mb-2">
         <div class="col-md-4">
             <label class="form-label">Default table</label>
-            <input type="text" id="settingsTable" class="form-control" placeholder="Table name">
+            <input type="text" name="default_table" class="form-control" placeholder="Table name" value="{{ default_table }}">
         </div>
         <div class="col-md-4">
             <label class="form-label">Default IP column</label>
-            <input type="text" id="settingsIpCol" class="form-control" placeholder="client_ip">
+            <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
         </div>
     </div>
     <div class="row g-2 mb-2">
         <div class="col-md-2 ms-auto">
-            <button class="btn btn-primary w-100" onclick="saveSettings()">Save</button>
+            <button type="submit" class="btn btn-primary w-100">Save</button>
         </div>
     </div>
-</div>
-<script>
-function saveSettings() {
-    localStorage.setItem('mysql_table', document.getElementById('settingsTable').value);
-    localStorage.setItem('mysql_ip_column', document.getElementById('settingsIpCol').value);
-    alert('Settings saved');
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-    document.getElementById('settingsTable').value = localStorage.getItem('mysql_table') || '';
-    document.getElementById('settingsIpCol').value = localStorage.getItem('mysql_ip_column') || 'client_ip';
-});
-</script>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- persist table name and date range selections on MySQL lookup page
- default the date range to **Today** and restore previous values on load

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6868ca82ccc4832dbcabeda7162e5d3d