### PR TITLE
Enable threshold settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ configured you can fetch IP data from any table on the main page. When fetching
 from MySQL you can also specify a start and end time to run a query that counts
 IP occurrences between those timestamps.
 
+Use the `/settings` page to change the default table/column and tweak the
+thresholds used for dynamic IP classification without editing `.env`.
+
 Processed files are saved under `results/` and cached IP data is stored in the database defined by `DB_FILE`.
 
 ## Cached Data

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -13,6 +13,20 @@
             <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
         </div>
     </div>
+    <div class="row g-3 mb-2">
+        <div class="col-md-4">
+            <label class="form-label">High traffic threshold</label>
+            <input type="number" name="high_traffic_threshold" class="form-control" value="{{ high_traffic_threshold }}">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Subnet IP threshold</label>
+            <input type="number" name="subnet_ip_threshold" class="form-control" value="{{ subnet_ip_threshold }}">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label">Subnet view threshold</label>
+            <input type="number" name="subnet_view_threshold" class="form-control" value="{{ subnet_view_threshold }}">
+        </div>
+    </div>
     <div class="row g-2 mb-2">
         <div class="col-md-2 ms-auto">
             <button type="submit" class="btn btn-primary w-100">Save</button>


### PR DESCRIPTION
## Summary
- add thresholds for dynamic classification to `app_settings`
- update settings UI for threshold configuration
- retrieve thresholds from database when classifying IPs
- document new `/settings` page capabilities

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6868d707485c832db27408abe99b4380