### PR TITLE
Move danger zone to settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -338,6 +338,20 @@ def settings_page():
     row = conn.execute(
         'SELECT default_table, default_ip_column, high_traffic_threshold, subnet_ip_threshold, subnet_view_threshold FROM app_settings WHERE id=1'
     ).fetchone()
+
+    total_cursor = conn.execute('SELECT COUNT(*) FROM ip_cache')
+    total_ips = total_cursor.fetchone()[0]
+
+    unknown_cursor = conn.execute(
+        'SELECT COUNT(*) FROM ip_cache WHERE country = "Unknown" OR region = "Unknown" OR city = "Unknown"'
+    )
+    unknown_count = unknown_cursor.fetchone()[0]
+
+    error_cursor = conn.execute(
+        'SELECT COUNT(*) FROM ip_cache WHERE country = "Error" OR region = "Error" OR city = "Error"'
+    )
+    error_count = error_cursor.fetchone()[0]
+
     conn.close()
     default_table = row[0] if row else ''
     default_ip_col = row[1] if row else 'client_ip'
@@ -351,6 +365,9 @@ def settings_page():
         high_traffic_threshold=high_traffic,
         subnet_ip_threshold=subnet_ip,
         subnet_view_threshold=subnet_view,
+        total_ips=total_ips,
+        unknown_count=unknown_count,
+        error_count=error_count,
     )
 
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,48 +3,64 @@
 {% block content %}
 <h1 class="mb-4">⚙️ Settings</h1>
 
-<form method="post" class="card p-4 shadow-sm mb-4">
-    <h5 class="mb-3">MySQL Defaults</h5>
-    <div class="row g-3 mb-3">
-        <div class="col-md-4">
-            <label class="form-label">Default table</label>
-            <input type="text" name="default_table" class="form-control" placeholder="Table name" value="{{ default_table }}">
+<form method="post">
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">MySQL Defaults</h5>
         </div>
-        <div class="col-md-4">
-            <label class="form-label">Default IP column</label>
-            <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
-        </div>
-    </div>
-
-    <h5 class="mb-3">Dynamic IP Classification</h5>
-    <div class="row g-3 mb-3">
-        <div class="col-md-4">
-            <label class="form-label">High traffic threshold</label>
-            <input type="number" name="high_traffic_threshold" class="form-control" value="{{ high_traffic_threshold }}">
-        </div>
-        <div class="col-md-4">
-            <label class="form-label">Subnet IP threshold</label>
-            <input type="number" name="subnet_ip_threshold" class="form-control" value="{{ subnet_ip_threshold }}">
-        </div>
-        <div class="col-md-4">
-            <label class="form-label">Subnet view threshold</label>
-            <input type="number" name="subnet_view_threshold" class="form-control" value="{{ subnet_view_threshold }}">
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">Default table</label>
+                    <input type="text" name="default_table" class="form-control" placeholder="Table name" value="{{ default_table }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Default IP column</label>
+                    <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
+                </div>
+            </div>
         </div>
     </div>
 
-    <div class="row g-2 mb-2">
-        <div class="col-md-2 ms-auto">
-            <button type="submit" class="btn btn-primary w-100">Save</button>
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Dynamic IP Classification</h5>
         </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">High traffic threshold</label>
+                    <input type="number" name="high_traffic_threshold" class="form-control" value="{{ high_traffic_threshold }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Subnet IP threshold</label>
+                    <input type="number" name="subnet_ip_threshold" class="form-control" value="{{ subnet_ip_threshold }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Subnet view threshold</label>
+                    <input type="number" name="subnet_view_threshold" class="form-control" value="{{ subnet_view_threshold }}">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="text-end mb-4">
+        <button type="submit" class="btn btn-primary">Save</button>
     </div>
 </form>
 
-<div class="card p-4 shadow-sm bg-light border border-danger">
-    <h3>⚠️ Danger Zone</h3>
-    <p>Fix problematic cache entries or clean all data (cleaning cannot be undone!)</p>
-    <button onclick="fixCache()" class="btn btn-success me-2">Fix Unknown/Error IPs ({{ unknown_count + error_count }})</button>
-    <button onclick="cleanCache()" class="btn btn-danger me-2">Clean All Cache ({{ total_ips }} records)</button>
-    <button onclick="cleanResults()" class="btn btn-danger">Clean All Processed Files</button>
+<div class="card shadow-sm mb-4 border-danger">
+    <div class="card-header bg-danger text-white">
+        <h5 class="mb-0">⚠️ Danger Zone</h5>
+    </div>
+    <div class="card-body">
+        <p class="mb-3">Fix problematic cache entries or clean all data (cleaning cannot be undone!)</p>
+        <div class="d-flex flex-wrap gap-2">
+            <button onclick="fixCache()" class="btn btn-success">Fix Unknown/Error IPs ({{ unknown_count + error_count }})</button>
+            <button onclick="cleanCache()" class="btn btn-danger">Clean All Cache ({{ total_ips }} records)</button>
+            <button onclick="cleanResults()" class="btn btn-danger">Clean All Processed Files</button>
+        </div>
+    </div>
 </div>
 
 <script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2,8 +2,10 @@
 {% block title %}Settings{% endblock %}
 {% block content %}
 <h1 class="mb-4">⚙️ Settings</h1>
-<form method="post" class="card p-4 shadow-sm">
-    <div class="row g-3 mb-2">
+
+<form method="post" class="card p-4 shadow-sm mb-4">
+    <h5 class="mb-3">MySQL Defaults</h5>
+    <div class="row g-3 mb-3">
         <div class="col-md-4">
             <label class="form-label">Default table</label>
             <input type="text" name="default_table" class="form-control" placeholder="Table name" value="{{ default_table }}">
@@ -13,7 +15,9 @@
             <input type="text" name="default_ip_column" class="form-control" placeholder="client_ip" value="{{ default_ip_col }}">
         </div>
     </div>
-    <div class="row g-3 mb-2">
+
+    <h5 class="mb-3">Dynamic IP Classification</h5>
+    <div class="row g-3 mb-3">
         <div class="col-md-4">
             <label class="form-label">High traffic threshold</label>
             <input type="number" name="high_traffic_threshold" class="form-control" value="{{ high_traffic_threshold }}">
@@ -27,10 +31,79 @@
             <input type="number" name="subnet_view_threshold" class="form-control" value="{{ subnet_view_threshold }}">
         </div>
     </div>
+
     <div class="row g-2 mb-2">
         <div class="col-md-2 ms-auto">
             <button type="submit" class="btn btn-primary w-100">Save</button>
         </div>
     </div>
 </form>
+
+<div class="card p-4 shadow-sm bg-light border border-danger">
+    <h3>⚠️ Danger Zone</h3>
+    <p>Fix problematic cache entries or clean all data (cleaning cannot be undone!)</p>
+    <button onclick="fixCache()" class="btn btn-success me-2">Fix Unknown/Error IPs ({{ unknown_count + error_count }})</button>
+    <button onclick="cleanCache()" class="btn btn-danger me-2">Clean All Cache ({{ total_ips }} records)</button>
+    <button onclick="cleanResults()" class="btn btn-danger">Clean All Processed Files</button>
+</div>
+
+<script>
+    async function cleanCache() {
+        if (!confirm('Are you sure you want to delete ALL cached IP data? This cannot be undone!')) return;
+
+        try {
+            const response = await fetch('/clean-cache', { method: 'POST' });
+            if (response.ok) {
+                alert('Cache cleaned successfully!');
+                location.reload();
+            } else {
+                const error = await response.json();
+                alert(`Error: ${error.error}`);
+            }
+        } catch (error) {
+            alert(`Error: ${error.message}`);
+        }
+    }
+
+    async function fixCache() {
+        if (!confirm('This will re-lookup all IPs with Unknown/Error data. Continue?')) return;
+
+        const btn = event.target;
+        btn.disabled = true;
+        btn.textContent = 'Fixing...';
+
+        try {
+            const response = await fetch('/fix-cache', { method: 'POST' });
+            const data = await response.json();
+
+            if (response.ok) {
+                alert(`Fixed ${data.fixed} out of ${data.total} problematic IPs!`);
+                location.reload();
+            } else {
+                alert(`Error: ${data.error}`);
+            }
+        } catch (error) {
+            alert(`Error: ${error.message}`);
+        } finally {
+            btn.disabled = false;
+            btn.textContent = 'Fix Unknown/Error IPs';
+        }
+    }
+
+    async function cleanResults() {
+        if (!confirm('Are you sure you want to delete ALL processed files? This cannot be undone!')) return;
+
+        try {
+            const response = await fetch('/clean-results', { method: 'POST' });
+            if (response.ok) {
+                alert('Processed files cleaned successfully!');
+            } else {
+                const error = await response.json();
+                alert(`Error: ${error.error}`);
+            }
+        } catch (error) {
+            alert(`Error: ${error.message}`);
+        }
+    }
+</script>
 {% endblock %}

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -14,8 +14,6 @@
     a { color: #007cba; text-decoration: none; }
     a:hover { text-decoration: underline; }
     .nav-links { display: flex; gap: 15px; }
-    .clean-section { margin: 30px 0; }
-    .clean-btn { margin: 5px; }
 </style>
 {% endblock %}
 {% block content %}
@@ -71,71 +69,5 @@
     </div>
 </div>
 
-<div class="clean-section card p-4 shadow-sm bg-light border border-danger">
-    <h3>⚠️ Danger Zone</h3>
-    <p>Fix problematic cache entries or clean all data (cleaning cannot be undone!)</p>
-    <button onclick="fixCache()" class="btn btn-success clean-btn">Fix Unknown/Error IPs</button>
-    <button onclick="cleanCache()" class="btn btn-danger clean-btn">Clean All Cache ({{ total_ips }} records)</button>
-    <button onclick="cleanResults()" class="btn btn-danger clean-btn">Clean All Processed Files</button>
-</div>
 
-<script>
-    async function cleanCache() {
-        if (!confirm('Are you sure you want to delete ALL cached IP data? This cannot be undone!')) return;
-
-        try {
-            const response = await fetch('/clean-cache', { method: 'POST' });
-            if (response.ok) {
-                alert('Cache cleaned successfully!');
-                location.reload();
-            } else {
-                const error = await response.json();
-                alert(`Error: ${error.error}`);
-            }
-        } catch (error) {
-            alert(`Error: ${error.message}`);
-        }
-    }
-
-    async function fixCache() {
-        if (!confirm('This will re-lookup all IPs with Unknown/Error data. Continue?')) return;
-
-        const btn = event.target;
-        btn.disabled = true;
-        btn.textContent = 'Fixing...';
-
-        try {
-            const response = await fetch('/fix-cache', { method: 'POST' });
-            const data = await response.json();
-
-            if (response.ok) {
-                alert(`Fixed ${data.fixed} out of ${data.total} problematic IPs!`);
-                location.reload();
-            } else {
-                alert(`Error: ${data.error}`);
-            }
-        } catch (error) {
-            alert(`Error: ${error.message}`);
-        } finally {
-            btn.disabled = false;
-            btn.textContent = 'Fix Unknown/Error IPs';
-        }
-    }
-
-    async function cleanResults() {
-        if (!confirm('Are you sure you want to delete ALL processed files? This cannot be undone!')) return;
-
-        try {
-            const response = await fetch('/clean-results', { method: 'POST' });
-            if (response.ok) {
-                alert('Processed files cleaned successfully!');
-            } else {
-                const error = await response.json();
-                alert(`Error: ${error.error}`);
-            }
-        } catch (error) {
-            alert(`Error: ${error.message}`);
-        }
-    }
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move *Danger Zone* cleaning controls from statistics page to settings
- add MySQL and dynamic IP classification sections to settings
- show number of problematic IPs in settings danger zone
- remove danger zone from statistics page

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868dd0ade8c832db25e5613188d8dfc