### PR TITLE
Improve MySQL connection UI

### DIFF
--- a/templates/connections.html
+++ b/templates/connections.html
@@ -7,24 +7,37 @@
 {% endblock %}
 {% block content %}
 <h1 class="mb-4">🔌 MySQL Connections</h1>
-<div class="card p-4 shadow-sm mb-3">
-    <form method="post">
-        <div class="row g-2">
-            <div class="col"><input type="text" class="form-control" name="name" placeholder="Name" required></div>
-            <div class="col"><input type="text" class="form-control" name="host" placeholder="Host" required></div>
-            <div class="col"><input type="number" class="form-control" name="port" value="3306" placeholder="Port" required></div>
-            <div class="col"><input type="text" class="form-control" name="user" placeholder="User" required></div>
-            <div class="col"><input type="password" class="form-control" name="password" placeholder="Password" required></div>
-            <div class="col"><input type="text" class="form-control" name="database" placeholder="Database" required></div>
-            <div class="col"><button type="submit" class="btn btn-primary">Add</button></div>
-        </div>
+
+<button class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#addConnModal">Add Connection</button>
+
+<!-- Add connection modal -->
+<div class="modal fade" id="addConnModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form method="post" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Add Connection</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3"><label class="form-label">Name</label><input type="text" class="form-control" name="name" required></div>
+        <div class="mb-3"><label class="form-label">Host</label><input type="text" class="form-control" name="host" required></div>
+        <div class="mb-3"><label class="form-label">Port</label><input type="number" class="form-control" name="port" value="3306" required></div>
+        <div class="mb-3"><label class="form-label">User</label><input type="text" class="form-control" name="user" required></div>
+        <div class="mb-3"><label class="form-label">Password</label><input type="password" class="form-control" name="password" required></div>
+        <div class="mb-3"><label class="form-label">Database</label><input type="text" class="form-control" name="database" required></div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
     </form>
+  </div>
 </div>
+
 {% if connections %}
 <div class="card p-4 shadow-sm">
     <table class="table table-sm table-striped">
         <thead>
-            <tr><th>Name</th><th>Host</th><th>Port</th><th>User</th><th>Database</th><th></th></tr>
+            <tr><th>Name</th><th>Host</th><th>Port</th><th>User</th><th>Database</th><th>Actions</th></tr>
         </thead>
         <tbody>
         {% for c in connections %}
@@ -34,8 +47,9 @@
                 <td>{{ c['port'] }}</td>
                 <td>{{ c['user'] }}</td>
                 <td>{{ c['database'] }}</td>
-                <td>
-                    <form method="post" action="{{ url_for('delete_connection', conn_id=c['id']) }}" onsubmit="return confirm('Delete connection?');">
+                <td class="text-nowrap">
+                    <button type="button" class="btn btn-secondary btn-sm me-1" onclick="testConn({{ c['id'] }})">Test</button>
+                    <form method="post" class="d-inline" action="{{ url_for('delete_connection', conn_id=c['id']) }}" onsubmit="return confirm('Delete connection?');">
                         <button class="btn btn-danger btn-sm">Delete</button>
                     </form>
                 </td>
@@ -47,4 +61,24 @@
 {% else %}
 <p>No connections configured.</p>
 {% endif %}
+
+<div id="testAlert" class="alert d-none mt-3"></div>
+
+<script>
+async function testConn(id) {
+    const alertBox = document.getElementById('testAlert');
+    alertBox.className = 'alert alert-info';
+    alertBox.textContent = 'Testing connection...';
+    alertBox.classList.remove('d-none');
+    const resp = await fetch(`/connections/test/${id}`, {method: 'POST'});
+    const data = await resp.json();
+    if (data.success) {
+        alertBox.className = 'alert alert-success';
+        alertBox.textContent = 'Connection successful';
+    } else {
+        alertBox.className = 'alert alert-danger';
+        alertBox.textContent = 'Error: ' + (data.message || 'Failed');
+    }
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add modal-based MySQL connection form with test button
- allow testing connections from the UI via new `/connections/test` endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6868e0df021c832d80c86ee0c1d5d73b