### PR TITLE
Include connection name in DB lookup files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ configured you can fetch IP data from any table on the main page. When fetching
 from MySQL you can also specify a start and end time to run a query that counts
 IP occurrences between those timestamps.
 
+Results generated from the DB lookup now include the configured connection name
+in the filename (e.g. `mysql_myconn_table_timestamp.csv`) so it's easy to see
+where each file originated.
+
 Use the `/settings` page to change the default table/column and tweak the
 thresholds used for dynamic IP classification without editing `.env`.
 

--- a/app.py
+++ b/app.py
@@ -761,7 +761,8 @@ def fetch_mysql():
         total_ips = len(ips)
         processed = 0
         os.makedirs('results', exist_ok=True)
-        filename = f"mysql_{table}_{int(time.time())}.csv"
+        conn_name = re.sub(r'[^A-Za-z0-9]+', '_', row['name']).strip('_')
+        filename = f"mysql_{conn_name}_{table}_{int(time.time())}.csv"
         filepath = os.path.join('results', filename)
 
         with open(filepath, 'w', newline='') as f:


### PR DESCRIPTION
## Summary
- include DB connection name in MySQL lookup result filenames
- document new file naming format in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6868e381e068832dad18a15a7b4af3ab